### PR TITLE
Add unit tests for export, search-within-note, and notebook nesting

### DIFF
--- a/src/services/export.test.ts
+++ b/src/services/export.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, describe } from 'bun:test';
+import { exportNoteToMarkdown, exportNoteToJSON } from './export';
+import type { Note, Cell } from '../types';
+
+let cellId = 0;
+function cell(partial: Partial<Cell> & Pick<Cell, 'type' | 'data'>): Cell {
+  return { id: `c${cellId++}`, sortOrder: 0, ...partial };
+}
+
+function note(cells: Cell[], overrides: Partial<Note> = {}): Note {
+  return {
+    id: 'n1',
+    notebookId: 'nb1',
+    title: 'My Note',
+    cells,
+    tags: [],
+    isFavorite: false,
+    isTrashed: false,
+    sortOrder: 0,
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+describe('exportNoteToMarkdown', () => {
+  test('renders the title as an H1', () => {
+    const md = exportNoteToMarkdown(note([]));
+    expect(md.startsWith('# My Note\n')).toBe(true);
+  });
+
+  test('renders tags with a hash prefix only when present', () => {
+    expect(exportNoteToMarkdown(note([]))).not.toContain('Tags:');
+    const md = exportNoteToMarkdown(note([], { tags: ['rust', 'tauri'] }));
+    expect(md).toContain('Tags: #rust #tauri');
+  });
+
+  test('wraps code cells in a fence carrying the language', () => {
+    const md = exportNoteToMarkdown(
+      note([cell({ type: 'code', data: 'let x = 1;', language: 'rust' })])
+    );
+    expect(md).toContain('```rust\nlet x = 1;\n```');
+  });
+
+  test('wraps latex cells in $$ delimiters', () => {
+    const md = exportNoteToMarkdown(note([cell({ type: 'latex', data: 'E = mc^2' })]));
+    expect(md).toContain('$$\nE = mc^2\n$$');
+  });
+
+  test('exports diagram cells as mermaid fences', () => {
+    const md = exportNoteToMarkdown(
+      note([cell({ type: 'diagram', data: 'graph TD; A-->B' })])
+    );
+    expect(md).toContain('```mermaid\ngraph TD; A-->B\n```');
+  });
+
+  test('emits text and markdown cells verbatim', () => {
+    const md = exportNoteToMarkdown(
+      note([
+        cell({ type: 'text', data: 'plain text' }),
+        cell({ type: 'markdown', data: '## heading' }),
+      ])
+    );
+    expect(md).toContain('plain text');
+    expect(md).toContain('## heading');
+  });
+});
+
+describe('exportNoteToJSON', () => {
+  test('produces a versioned, round-trippable payload', () => {
+    const original = note(
+      [cell({ type: 'code', data: 'print(1)', language: 'python' })],
+      { tags: ['x'] }
+    );
+    const parsed = JSON.parse(exportNoteToJSON(original));
+
+    expect(parsed.version).toBe(1);
+    expect(parsed.title).toBe('My Note');
+    expect(parsed.tags).toEqual(['x']);
+    expect(parsed.createdAt).toBe(1000);
+    expect(parsed.updatedAt).toBe(2000);
+    expect(parsed.cells).toEqual([
+      { type: 'code', data: 'print(1)', language: 'python', diagramType: undefined },
+    ]);
+  });
+
+  test('omits internal fields like id and notebookId', () => {
+    const json = exportNoteToJSON(note([]));
+    expect(json).not.toContain('notebookId');
+    expect(json).not.toContain('isTrashed');
+  });
+});

--- a/src/services/search.test.ts
+++ b/src/services/search.test.ts
@@ -1,0 +1,88 @@
+import { test, expect, describe } from 'bun:test';
+import { searchWithinNote, highlightMatches } from './search';
+import type { Note, Cell } from '../types';
+
+function cell(data: string, id = 'c'): Cell {
+  return { id, type: 'text', data, sortOrder: 0 };
+}
+
+function note(cells: Cell[]): Note {
+  return {
+    id: 'n1',
+    notebookId: 'nb1',
+    title: 'Test note',
+    cells,
+    tags: [],
+    isFavorite: false,
+    isTrashed: false,
+    sortOrder: 0,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('searchWithinNote', () => {
+  test('finds a match and reports its offsets', () => {
+    const results = searchWithinNote(note([cell('hello world')]), 'world');
+    expect(results).toEqual([{ cellIndex: 0, matches: [{ start: 6, end: 11 }] }]);
+  });
+
+  test('is case insensitive', () => {
+    const results = searchWithinNote(note([cell('Hello World')]), 'hello');
+    expect(results).toEqual([{ cellIndex: 0, matches: [{ start: 0, end: 5 }] }]);
+  });
+
+  test('finds multiple matches within one cell', () => {
+    const results = searchWithinNote(note([cell('aa aa aa')]), 'aa');
+    expect(results[0].matches).toHaveLength(3);
+    expect(results[0].matches.map(m => m.start)).toEqual([0, 3, 6]);
+  });
+
+  test('finds overlapping matches', () => {
+    // 'aaa' contains 'aa' at offsets 0 and 1 because the scan advances by one.
+    const results = searchWithinNote(note([cell('aaa')]), 'aa');
+    expect(results[0].matches.map(m => m.start)).toEqual([0, 1]);
+  });
+
+  test('reports the correct cell index and skips cells with no match', () => {
+    const results = searchWithinNote(
+      note([cell('nothing', 'a'), cell('find me', 'b')]),
+      'find'
+    );
+    expect(results).toEqual([{ cellIndex: 1, matches: [{ start: 0, end: 4 }] }]);
+  });
+
+  test('returns no results when nothing matches', () => {
+    expect(searchWithinNote(note([cell('hello')]), 'xyz')).toEqual([]);
+  });
+});
+
+describe('highlightMatches', () => {
+  test('wraps a match in the default highlight span', () => {
+    expect(highlightMatches('hello world', 'world')).toBe(
+      'hello <span class="search-highlight">world</span>'
+    );
+  });
+
+  test('highlights every occurrence, preserving original case', () => {
+    expect(highlightMatches('Cat cat CAT', 'cat')).toBe(
+      '<span class="search-highlight">Cat</span> ' +
+        '<span class="search-highlight">cat</span> ' +
+        '<span class="search-highlight">CAT</span>'
+    );
+  });
+
+  test('accepts a custom highlight class', () => {
+    expect(highlightMatches('abc', 'b', 'hit')).toBe('a<span class="hit">b</span>c');
+  });
+
+  test('treats regex metacharacters in the query literally', () => {
+    expect(highlightMatches('a.b a-b', 'a.b')).toBe(
+      '<span class="search-highlight">a.b</span> a-b'
+    );
+  });
+
+  test('returns the text unchanged for an empty query', () => {
+    expect(highlightMatches('hello', '   ')).toBe('hello');
+  });
+});

--- a/src/utils/notebooks.test.ts
+++ b/src/utils/notebooks.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, describe } from 'bun:test';
+import { isDescendantOf, getNotebookSubtreeIds } from './notebooks';
+import type { Notebook } from '../types';
+
+// Helper to build a minimal Notebook with just the fields these functions read.
+function nb(id: string, parentId?: string): Notebook {
+  return {
+    id,
+    name: id,
+    parentId,
+    sortOrder: 0,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+// A small tree:
+//   root
+//   ├── a
+//   │   └── a1
+//   └── b
+//   orphan (no parent, unrelated)
+const tree: Notebook[] = [
+  nb('root'),
+  nb('a', 'root'),
+  nb('a1', 'a'),
+  nb('b', 'root'),
+  nb('orphan'),
+];
+
+describe('isDescendantOf', () => {
+  test('direct child is a descendant', () => {
+    expect(isDescendantOf(tree, 'a', 'root')).toBe(true);
+  });
+
+  test('deep descendant is found through the chain', () => {
+    expect(isDescendantOf(tree, 'a1', 'root')).toBe(true);
+  });
+
+  test('unrelated notebook is not a descendant', () => {
+    expect(isDescendantOf(tree, 'orphan', 'root')).toBe(false);
+  });
+
+  test('sibling is not a descendant', () => {
+    expect(isDescendantOf(tree, 'b', 'a')).toBe(false);
+  });
+
+  test('a notebook is not its own descendant', () => {
+    expect(isDescendantOf(tree, 'root', 'root')).toBe(false);
+  });
+
+  test('unknown id returns false', () => {
+    expect(isDescendantOf(tree, 'missing', 'root')).toBe(false);
+  });
+});
+
+describe('getNotebookSubtreeIds', () => {
+  test('includes the notebook itself', () => {
+    expect(getNotebookSubtreeIds(tree, 'a1')).toEqual(new Set(['a1']));
+  });
+
+  test('collects all transitive descendants', () => {
+    expect(getNotebookSubtreeIds(tree, 'root')).toEqual(
+      new Set(['root', 'a', 'a1', 'b'])
+    );
+  });
+
+  test('collects a partial subtree from a mid-level node', () => {
+    expect(getNotebookSubtreeIds(tree, 'a')).toEqual(new Set(['a', 'a1']));
+  });
+
+  test('an unknown id yields just that id', () => {
+    expect(getNotebookSubtreeIds(tree, 'missing')).toEqual(new Set(['missing']));
+  });
+});


### PR DESCRIPTION
Adds unit tests for the pure logic in three modules:

- `export.test.ts` — `exportNoteToMarkdown` / `exportNoteToJSON` rendering
- `search.test.ts` — `searchWithinNote` (match offsets, case-insensitivity, overlaps) and `highlightMatches`
- `notebooks.test.ts` — notebook nesting/descendant helpers

All tests run under `bun test` with no Tauri/SQLite dependency.