### PR TITLE
Extract pure quiver-note-url rewriter + add regression tests

### DIFF
--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -920,6 +920,32 @@ export async function searchNotes(query: string): Promise<Note[]> {
 // ==================== LINK REWRITING ====================
 
 /**
+ * Rewrite quiver-note-url links in a single string given a UUID→noteId map.
+ * Handles the various Quiver URL spellings -- `quiver-note-url://UUID`,
+ * `quiver-note-url:UUID`, and the bare `quiver-note-url/UUID` form (issue #2).
+ * UUIDs are matched case-insensitively; unresolved links are left untouched.
+ * Pure and exported for testing.
+ */
+export function rewriteQuiverLinksInText(
+  text: string,
+  uuidToNoteId: Map<string, string>
+): { text: string; rewritten: number } {
+  let rewritten = 0;
+  const updated = text.replace(
+    /quiver-note-url:?\/?\/?\/?([0-9A-Fa-f-]+)/gi,
+    (match, quiverUuid) => {
+      const noteId = uuidToNoteId.get(quiverUuid.toLowerCase());
+      if (noteId) {
+        rewritten++;
+        return `notch://note/${noteId}`;
+      }
+      return match; // leave unresolved links unchanged
+    }
+  );
+  return { text: updated, rewritten };
+}
+
+/**
  * Rewrite quiver-note-url:// links to notch://note/ links in all cell data.
  * Builds a map from Quiver source UUIDs to Notch note IDs, then replaces
  * all matching URLs in cell data.
@@ -943,17 +969,8 @@ export async function rewriteQuiverNoteLinks(): Promise<number> {
 
   let rewritten = 0;
   for (const cell of cellRows) {
-    const updated = cell.data.replace(
-      /quiver-note-url:?\/?\/?\/?([0-9A-Fa-f-]+)/gi,
-      (match, quiverUuid) => {
-        const noteId = uuidToNoteId.get(quiverUuid.toLowerCase());
-        if (noteId) {
-          rewritten++;
-          return `notch://note/${noteId}`;
-        }
-        return match; // leave unresolved links unchanged
-      }
-    );
+    const { text: updated, rewritten: count } = rewriteQuiverLinksInText(cell.data, uuidToNoteId);
+    rewritten += count;
     if (updated !== cell.data) {
       await getDb().execute('UPDATE cells SET data = ? WHERE id = ?', [updated, cell.id]);
     }

--- a/src/services/quiverLinks.test.ts
+++ b/src/services/quiverLinks.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe } from 'bun:test';
+import { rewriteQuiverLinksInText } from './database';
+
+// A resolved Quiver UUID -> Notch note id map. Keys are lowercase, matching how
+// rewriteQuiverNoteLinks builds the map (case-insensitive lookups).
+const map = new Map([['a1b2-c3d4', 'note-1']]);
+
+describe('rewriteQuiverLinksInText', () => {
+  test('rewrites the canonical quiver-note-url:// form', () => {
+    const { text, rewritten } = rewriteQuiverLinksInText(
+      'see [foo](quiver-note-url://a1b2-c3d4)',
+      map
+    );
+    expect(text).toBe('see [foo](notch://note/note-1)');
+    expect(rewritten).toBe(1);
+  });
+
+  test('rewrites the bare slash form that previously crashed (issue #2)', () => {
+    // `quiver-note-url/UUID` -- no colon, single slash.
+    const { text, rewritten } = rewriteQuiverLinksInText('quiver-note-url/a1b2-c3d4', map);
+    expect(text).toBe('notch://note/note-1');
+    expect(rewritten).toBe(1);
+  });
+
+  test('rewrites the colon-only form', () => {
+    const { text } = rewriteQuiverLinksInText('quiver-note-url:a1b2-c3d4', map);
+    expect(text).toBe('notch://note/note-1');
+  });
+
+  test('matches UUIDs case-insensitively', () => {
+    const { text, rewritten } = rewriteQuiverLinksInText('quiver-note-url://A1B2-C3D4', map);
+    expect(text).toBe('notch://note/note-1');
+    expect(rewritten).toBe(1);
+  });
+
+  test('rewrites every link when several appear in one string', () => {
+    const m = new Map([
+      ['aaaa', 'note-a'],
+      ['bbbb', 'note-b'],
+    ]);
+    const { text, rewritten } = rewriteQuiverLinksInText(
+      'first quiver-note-url://aaaa then quiver-note-url://bbbb',
+      m
+    );
+    expect(text).toBe('first notch://note/note-a then notch://note/note-b');
+    expect(rewritten).toBe(2);
+  });
+
+  test('leaves links whose UUID is not in the map untouched', () => {
+    const { text, rewritten } = rewriteQuiverLinksInText(
+      'quiver-note-url://deadbeef',
+      map
+    );
+    expect(text).toBe('quiver-note-url://deadbeef');
+    expect(rewritten).toBe(0);
+  });
+
+  test('returns text unchanged when there are no quiver links', () => {
+    const input = 'just some [markdown](https://example.com) text';
+    const { text, rewritten } = rewriteQuiverLinksInText(input, map);
+    expect(text).toBe(input);
+    expect(rewritten).toBe(0);
+  });
+});


### PR DESCRIPTION
Two commits:

1. **Refactor** — extract the quiver-note-url rewriting logic out of `rewriteQuiverNoteLinks` (which needs a live SQLite handle) into a pure, exported `rewriteQuiverLinksInText`. Behavior-preserving. So I could more easily test it in (2).
2. **Tests** — `rewriteQuiverLinksInText` handles every quiver-note-url spelling, including the bare-slash form that crashed (#2), multiple links per cell, case-insensitive UUIDs, and leaving unresolved links untouched.
