### PR TITLE
Fix code block min-height; correct updater signing key

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,18 +22,20 @@ updater plugin.
 
 ### Required — updater signing
 
-The signing keypair was generated locally at `~/.tauri/notch.key` (private) and
-`~/.tauri/notch.key.pub` (public, already committed in `tauri.conf.json`). Add
-the private key as a repo secret:
+The signing keypair lives locally at `~/.tauri/notch.key` (private) and
+`~/.tauri/notch.key.pub` (public, already committed in `tauri.conf.json`). Its
+password is stored at `~/.tauri/notch.pass`. Both repo secrets are already set;
+to (re)create them:
 
 ```sh
 gh secret set TAURI_SIGNING_PRIVATE_KEY < ~/.tauri/notch.key
-gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --body ""
+gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD < ~/.tauri/notch.pass
 ```
 
-> ⚠️ **Back up `~/.tauri/notch.key`.** If you lose it you can no longer sign
-> updates that existing installs will accept — you'd have to ship a new public
-> key, which breaks the update chain for everyone already on an old version.
+> ⚠️ **Back up `~/.tauri/notch.key` and `~/.tauri/notch.pass`** (e.g. to a
+> password manager). If you lose either you can no longer sign updates that
+> existing installs will accept — you'd have to ship a new public key, which
+> breaks the update chain for everyone already on an old version.
 
 ### Optional — Apple Developer ID signing & notarization
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-shell": "^2.0.0",
         "@tauri-apps/plugin-sql": "^2.0.0",
-        "@tauri-apps/plugin-updater": "^2.10.1",
+        "@tauri-apps/plugin-updater": "~2.9.0",
         "dompurify": "^3.3.1",
         "highlight.js": "^11.9.0",
         "katex": "^0.16.9",
@@ -109,7 +109,7 @@
 
     "@tauri-apps/plugin-sql": ["@tauri-apps/plugin-sql@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-iNgHnFIR+jRkx9INKVKepzMlxXtNkJUaWuhagFjT4dOttPaNyRnVHgwTjpqZhyVjiklDh2UdEPAJkQKiCPAekw=="],
 
-    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.9.0", "", { "dependencies": { "@tauri-apps/api": "^2.6.0" } }, "sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg=="],
 
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@tauri-apps/plugin-sql": "^2.0.0",
-    "@tauri-apps/plugin-updater": "^2.10.1",
+    "@tauri-apps/plugin-updater": "~2.9.0",
     "dompurify": "^3.3.1",
     "highlight.js": "^11.9.0",
     "katex": "^0.16.9",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "notch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2572,7 +2572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5558,7 +5558,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -72,7 +72,7 @@
       "endpoints": [
         "https://github.com/sb-/notch/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDIyMjY1RUVFQTQwMjEwQkMKUldTOEVBS2s3bDRtSW9yTUVZWUUrc0drclQwRlFJcE5mOUYyL2toRU81a1dLbkdna0VqMzlQVTQK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENEQTlBRUEyRDI2M0IxMzEKUldReHNXUFNvcTZweldQVWNzekk4ZVlmNWd6OFZSOWYrelU2VUVYZFljcGEyWG0xbUdadEdTNXcK"
     }
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1201,7 +1201,9 @@ body {
 
 .monaco-container {
   width: 100%;
-  min-height: 60px;
+  /* One line: EDITOR_LINE_HEIGHT (21) + HORIZONTAL_SCROLLBAR_RESERVE (8) in CodeCell.tsx.
+     The inline height from JS drives the real size; this is just a floor. */
+  min-height: 29px;
   background: #1e1e1e;
 }
 


### PR DESCRIPTION
## Summary
- **Code block height**: `.monaco-container` had `min-height: 60px`, forcing a single-line code cell to render ~2× taller than its content. Reduced to `29px` to match `CodeCell.tsx`'s computed one-line height (`EDITOR_LINE_HEIGHT` 21 + 8px scrollbar reserve).
- **Updater signing key**: the key was generated with an empty password, which does **not** round-trip with the Tauri signer (`tauri build` failed with "incorrect updater private key password"). Regenerated with a real password, updated the committed `pubkey` and the `TAURI_SIGNING_*` GitHub secrets.
- **Plugin version**: pinned `@tauri-apps/plugin-updater` to `~2.9.0` to match the Rust crate (npm had drifted to 2.10; `tauri build` rejects the mismatch).
- Updated `RELEASING.md` for the new password file (`~/.tauri/notch.pass`).

## Test plan
- `bun run build` now completes end-to-end, producing a signed `.dmg`, `.app.tar.gz`, and `.app.tar.gz.sig`.
- Installed `Notch.app` to `/Applications` and launched to verify the code-block height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)