### PR TITLE
Add `=WIDTHxHEIGHT` sizing suffix for markdown images

### DIFF
--- a/src/services/markdown.test.ts
+++ b/src/services/markdown.test.ts
@@ -27,6 +27,12 @@ test('preserves alt text and title alongside size', () => {
   expect(html).toContain('width="300"');
 });
 
+test('escaped `]` in alt is supported and unescaped', () => {
+  const html = renderMarkdown('![a \\] b](https://example.com/cat.png =400x)');
+  expect(html).toContain('alt="a ] b"');
+  expect(html).toContain('width="400"');
+});
+
 test('plain images without a size suffix are unaffected', () => {
   const html = renderMarkdown('![cat](https://example.com/cat.png)');
   expect(html).toContain('src="https://example.com/cat.png"');

--- a/src/services/markdown.test.ts
+++ b/src/services/markdown.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from 'bun:test';
+import { renderMarkdown } from './markdown';
+
+test('renders width-only size suffix `=300x`', () => {
+  const html = renderMarkdown('![cat](https://example.com/cat.png =300x)');
+  expect(html).toContain('src="https://example.com/cat.png"');
+  expect(html).toContain('width="300"');
+  expect(html).not.toContain('height=');
+});
+
+test('renders width and height `=300x200`', () => {
+  const html = renderMarkdown('![cat](https://example.com/cat.png =300x200)');
+  expect(html).toContain('width="300"');
+  expect(html).toContain('height="200"');
+});
+
+test('renders height-only size suffix `=x200`', () => {
+  const html = renderMarkdown('![cat](https://example.com/cat.png =x200)');
+  expect(html).toContain('height="200"');
+  expect(html).not.toContain('width=');
+});
+
+test('preserves alt text and title alongside size', () => {
+  const html = renderMarkdown('![a cat](https://example.com/cat.png =300x "Tabby")');
+  expect(html).toContain('alt="a cat"');
+  expect(html).toContain('title="Tabby"');
+  expect(html).toContain('width="300"');
+});
+
+test('plain images without a size suffix are unaffected', () => {
+  const html = renderMarkdown('![cat](https://example.com/cat.png)');
+  expect(html).toContain('src="https://example.com/cat.png"');
+  expect(html).not.toContain('width=');
+  expect(html).not.toContain('height=');
+});
+
+test('`=x` with no dimensions is not treated as a size suffix', () => {
+  // The bare `=x` should not produce width/height attributes. (marked's
+  // built-in image rule drops the image because of the space, which is the
+  // pre-existing behavior for a malformed suffix.)
+  const html = renderMarkdown('![cat](https://example.com/cat.png =x)');
+  expect(html).not.toContain('width=');
+  expect(html).not.toContain('height=');
+});

--- a/src/services/markdown.ts
+++ b/src/services/markdown.ts
@@ -80,17 +80,24 @@ const inlineMath = {
 //
 // The pattern is a hand-rolled clone of marked's image rule, composed from
 // labeled fragments so each maps to one part of the grammar. Known limits
-// (acceptable for this app's resource URLs): alt cannot contain `]`, href
-// cannot contain spaces, and only double-quoted titles are recognized.
+// (acceptable for this app's resource URLs): alt cannot contain an unescaped
+// `]`, href cannot contain spaces, and only double-quoted titles are recognized.
 const SIZED_IMAGE_RE = new RegExp(
   '^' + [
-    /!\[([^\]]*)\]/,        // ![alt]                  -> group 1: alt text
-    /\(\s*<?([^\s>]+)>?/,   // (url  (optional <...>)   -> group 2: href
-    /\s+=(\d*)x(\d*)/,      //  =WxH                    -> groups 3, 4: width, height
-    /(?:\s+"([^"]*)")?/,    //  "title"  (optional)     -> group 5: title
-    /\s*\)/,                // )
+    /!\[((?:\\.|[^\]])*)\]/, // ![alt]  (\] escapes ok)  -> group 1: alt text
+    /\(\s*<?([^\s>]+)>?/,    // (url  (optional <...>)   -> group 2: href
+    /\s+=(\d*)x(\d*)/,       //  =WxH                    -> groups 3, 4: width, height
+    /(?:\s+"([^"]*)")?/,     //  "title"  (optional)     -> group 5: title
+    /\s*\)/,                 // )
   ].map((part) => part.source).join(''),
 );
+
+// Undo CommonMark backslash escapes (e.g. `\]` -> `]`) so the alt text we emit
+// matches what marked produces for plain images.
+const ESCAPED_PUNCT = /\\([!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~])/g;
+function unescapeMarkdown(text: string): string {
+  return text.replace(ESCAPED_PUNCT, '$1');
+}
 
 const sizedImage = {
   name: 'sizedImage',
@@ -107,7 +114,7 @@ const sizedImage = {
     return {
       type: 'sizedImage',
       raw: match[0],
-      text: match[1] ?? '',
+      text: unescapeMarkdown(match[1] ?? ''),
       href: match[2] ?? '',
       width: match[3] ?? '',
       height: match[4] ?? '',

--- a/src/services/markdown.ts
+++ b/src/services/markdown.ts
@@ -13,6 +13,16 @@ interface MathToken {
   text: string;
 }
 
+interface SizedImageToken {
+  type: string;
+  raw: string;
+  text: string;
+  href: string;
+  width: string;
+  height: string;
+  title: string;
+}
+
 function renderMath(text: string, displayMode: boolean): string {
   try {
     return katex.renderToString(text, {
@@ -62,6 +72,58 @@ const inlineMath = {
   },
 };
 
+// Sized images: `![alt](url =WIDTHxHEIGHT)` (Quiver/Typora style). Plain marked
+// drops the whole image when the `=800x` suffix is present (the space breaks its
+// built-in image rule), so we re-parse the image ourselves and emit width/height
+// attributes. Images without a size suffix fall through to marked's built-in
+// image handling (the `image` renderer below).
+//
+// The pattern is a hand-rolled clone of marked's image rule, composed from
+// labeled fragments so each maps to one part of the grammar. Known limits
+// (acceptable for this app's resource URLs): alt cannot contain `]`, href
+// cannot contain spaces, and only double-quoted titles are recognized.
+const SIZED_IMAGE_RE = new RegExp(
+  '^' + [
+    /!\[([^\]]*)\]/,        // ![alt]                  -> group 1: alt text
+    /\(\s*<?([^\s>]+)>?/,   // (url  (optional <...>)   -> group 2: href
+    /\s+=(\d*)x(\d*)/,      //  =WxH                    -> groups 3, 4: width, height
+    /(?:\s+"([^"]*)")?/,    //  "title"  (optional)     -> group 5: title
+    /\s*\)/,                // )
+  ].map((part) => part.source).join(''),
+);
+
+const sizedImage = {
+  name: 'sizedImage',
+  level: 'inline' as const,
+  start(src: string) {
+    const i = src.indexOf('![');
+    return i < 0 ? undefined : i;
+  },
+  tokenizer(src: string): SizedImageToken | undefined {
+    const match = SIZED_IMAGE_RE.exec(src);
+    if (!match) return undefined;
+    // Require at least one dimension; `=x` is not a valid size suffix.
+    if (!match[3] && !match[4]) return undefined;
+    return {
+      type: 'sizedImage',
+      raw: match[0],
+      text: match[1] ?? '',
+      href: match[2] ?? '',
+      width: match[3] ?? '',
+      height: match[4] ?? '',
+      title: match[5] ?? '',
+    };
+  },
+  renderer(token: SizedImageToken) {
+    const src = resolveResourceUrl(token.href);
+    const altAttr = token.text ? ` alt="${token.text}"` : '';
+    const widthAttr = token.width ? ` width="${token.width}"` : '';
+    const heightAttr = token.height ? ` height="${token.height}"` : '';
+    const titleAttr = token.title ? ` title="${token.title}"` : '';
+    return `<img src="${src}"${altAttr}${widthAttr}${heightAttr}${titleAttr} />`;
+  },
+};
+
 md.use({
   gfm: true,
   breaks: true,
@@ -71,7 +133,7 @@ md.use({
       return undefined;
     },
   },
-  extensions: [blockMath, inlineMath],
+  extensions: [blockMath, inlineMath, sizedImage],
   renderer: {
     // Preserve notch:// and quiver-note-url:// protocols on links.
     link(href: string, title: string | null | undefined, text: string) {


### PR DESCRIPTION
## Summary

Adds support for the `=WIDTHxHEIGHT` image-sizing suffix in markdown, e.g.:

```md
![alt](notch-resource://<id> =400x)      → width 400
![alt](notch-resource://<id> =400x300)   → width 400, height 300
![alt](notch-resource://<id> =x300)      → height 300
```

This is the Quiver/Typora convention. Plain `marked` **drops the whole image** when the `=400x` suffix is present — the space after the URL breaks its built-in image rule, so the image renders as literal text. This PR adds a custom `marked` inline extension (`sizedImage`) that re-parses the sized form and emits `width`/`height` attributes.

Notes on the implementation:
- Only intercepts images that **carry a size suffix**; plain `![alt](url)` images continue to use `marked`'s built-in image handling untouched.
- Both `renderMarkdown` consumers (the preview and HTML export) insert output unsanitized, so `width`/`height` survive to the DOM with no `html.ts` changes.

## Before / After

`![IMAGE](notch-resource://… =400x)` in a note:

**Before** — the sized image renders as literal text:

<img width="1851" height="401" alt="image" src="https://github.com/user-attachments/assets/b52faed9-8b58-478b-9290-137ef0782f22" />

**After** — the image renders at the requested width:

![after](https://raw.githubusercontent.com/ijoseph/notch/pr-assets/after.png)

## Known limitation

The extension re-parses the image with a single regex rather than reusing `marked`'s hybrid (regex + procedural balanced-bracket scanning) parser, so the **sized** path supports a narrower grammar than plain images. The practical one to be aware of:

- **Nested (unescaped) square brackets in the alt/description text are not supported** for sized images — e.g. `![a [x] b](url =400x)` falls back to literal text, because correctly matching balanced brackets needs the procedural scanning `marked` does and this path uses a single regex. Escaped brackets (`![a \] b](url =400x)`) *are* supported. Plain (non-sized) images still handle the nested case via `marked`. Alt text in practice is usually a filename, so this is unlikely to bite.

(A fully robust alternative would preprocess the `=WxH` suffix out before `marked` parses, letting `marked` do the real image parse — happy to switch to that if preferred.)

## Tests

`src/services/markdown.test.ts` covers width-only / height-only / both, alt+title preservation, the malformed `=x` case, and that plain images are unaffected.

