### PR TITLE
feat(assistant): optional Pi-based LLM assistant

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,8 @@
     "": {
       "name": "notch",
       "dependencies": {
+        "@earendil-works/pi-agent-core": "0.79.7",
+        "@earendil-works/pi-ai": "0.79.7",
         "@monaco-editor/react": "^4.6.0",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
@@ -39,11 +41,93 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.22", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@aws-sdk/xml-builder": "^3.972.30", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.48", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.50", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/credential-provider-env": "^3.972.48", "@aws-sdk/credential-provider-http": "^3.972.50", "@aws-sdk/credential-provider-login": "^3.972.54", "@aws-sdk/credential-provider-process": "^3.972.48", "@aws-sdk/credential-provider-sso": "^3.972.54", "@aws-sdk/credential-provider-web-identity": "^3.972.54", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.57", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.48", "@aws-sdk/credential-provider-http": "^3.972.50", "@aws-sdk/credential-provider-ini": "^3.972.55", "@aws-sdk/credential-provider-process": "^3.972.48", "@aws-sdk/credential-provider-sso": "^3.972.54", "@aws-sdk/credential-provider-web-identity": "^3.972.54", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/credential-provider-imds": "^4.3.7", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.48", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/token-providers": "3.1071.0", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.54", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.22", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.18", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.30", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-kH6N4f/Fzi9r/dYap8EQ+Zk4NOz8pl4AtWKhzAoG2C1/4YkIHok9APp/e+75woreWQq264n+LkrJsJVZ0Q+M1Q=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.22", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.22", "@aws-sdk/signature-v4-multi-region": "^3.996.35", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.35", "", { "dependencies": { "@aws-sdk/types": "^3.973.13", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.973.13", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.4", "", {}, "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.7", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.7", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-kbwGwqq2oy0fr1WYCCgKavUriEL7pWQN/vkF8oCnZ8H+0xu86kAp1iHEVWsMm+NyslLCe4SA1ushfMT/yFhQfQ=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.7", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.1", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-KTe2euBoBEmFb0W+KR05Im8Qq4coU+eo46++UgNAfT3L8OIBv3QU+/pif9EqaFQ1QUmirv8kgy4TQltvrCu7iQ=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
 
     "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
+
+    "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
 
@@ -70,6 +154,24 @@
     "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
 
     "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
+    "@smithy/core": ["@smithy/core@3.25.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.5.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.5.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ=="],
+
+    "@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.9.1", "", {}, "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw=="],
 
@@ -137,11 +239,25 @@
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
+
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
@@ -223,6 +339,8 @@
 
     "dagre-d3-es": ["dagre-d3-es@7.0.13", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
     "dayjs": ["dayjs@1.11.19", "", {}, "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -237,15 +355,49 @@
 
     "dompurify": ["dompurify@3.3.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q=="],
 
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "elkjs": ["elkjs@0.9.3", "", {}, "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.7.3", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.7", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
+    "gaxios": ["gaxios@7.1.5", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "google-auth-library": ["google-auth-library@10.7.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "katex": ["katex@0.16.27", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw=="],
 
@@ -256,6 +408,8 @@
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lodash-es": ["lodash-es@4.17.22", "", {}, "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -315,11 +469,27 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
     "non-layered-tidy-tree-layout": ["non-layered-tidy-tree-layout@2.0.2", "", {}, "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "protobufjs": ["protobufjs@7.6.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
@@ -327,15 +497,25 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "stylis": ["stylis@4.3.6", "", {}, "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.1.38", "", {}, "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -349,9 +529,27 @@
 
     "uvu": ["uvu@0.5.6", "", { "dependencies": { "dequal": "^2.0.0", "diff": "^5.0.0", "kleur": "^4.0.3", "sade": "^1.7.3" }, "bin": { "uvu": "bin.js" } }, "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "web-worker": ["web-worker@1.5.0", "", {}, "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1071.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.22", "@aws-sdk/nested-clients": "^3.997.22", "@aws-sdk/types": "^3.973.13", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.8.1", "", { "dependencies": { "@smithy/core": "^3.25.1", "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw=="],
 
     "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,17 @@
     "dev": "bunx tauri dev",
     "dev:frontend": "bun run --hot src/index.ts",
     "build": "bunx tauri build",
-    "build:frontend": "bun build src/index.html --outdir dist --production",
+    "build:frontend": "bun build src/index.html --outdir dist --production --splitting",
     "preview": "bun run src/index.ts",
     "test": "bun test",
+    "assistant:e2e": "bun run scripts/assistant-e2e.ts",
     "tauri": "bunx tauri",
     "release": "bun run scripts/release.ts",
     "icons": "bun run scripts/generate-icons.ts && iconutil -c icns src-tauri/icons/icon.iconset -o src-tauri/icons/icon.icns"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "0.79.7",
+    "@earendil-works/pi-ai": "0.79.7",
     "@monaco-editor/react": "^4.6.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "bunx tauri dev",
     "dev:frontend": "bun run --hot src/index.ts",
     "build": "bunx tauri build",
-    "build:frontend": "bun build src/index.html --outdir dist --production --splitting",
+    "build:frontend": "bun build src/index.html --outdir dist --production",
     "preview": "bun run src/index.ts",
     "test": "bun test",
     "assistant:e2e": "bun run scripts/assistant-e2e.ts",

--- a/scripts/assistant-e2e.ts
+++ b/scripts/assistant-e2e.ts
@@ -1,0 +1,120 @@
+/**
+ * End-to-end check of the pi Agent integration against the local Ollama gemma
+ * models. Runs headlessly under bun (no Tauri/webview), exercising the same
+ * Agent + model configuration the app uses in src/assistant/agent.ts.
+ *
+ *   bun run scripts/assistant-e2e.ts
+ *   E2E_MODEL=gemma4:e4b bun run scripts/assistant-e2e.ts
+ *
+ * Requires `ollama serve` running with the gemma models pulled.
+ */
+
+import '@earendil-works/pi-ai'; // side-effect: register providers
+import { Agent } from '@earendil-works/pi-agent-core';
+import type { AgentEvent } from '@earendil-works/pi-agent-core';
+import type { Model } from '@earendil-works/pi-ai';
+import { Type } from 'typebox';
+
+const MODEL = process.env.E2E_MODEL ?? 'gemma3:4b';
+const TOOL_MODEL = process.env.E2E_TOOL_MODEL ?? MODEL;
+
+function buildModel(id: string): Model<'openai-completions'> {
+  return {
+    id,
+    name: id,
+    api: 'openai-completions',
+    provider: 'ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 2048,
+    compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
+  };
+}
+
+function assistantText(messages: { role: string; content: any[] }[]): string {
+  const last = [...messages].reverse().find(m => m.role === 'assistant');
+  if (!last) return '';
+  return last.content
+    .filter((c: any) => c.type === 'text')
+    .map((c: any) => c.text)
+    .join('');
+}
+
+let failures = 0;
+function check(name: string, ok: boolean, detail = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  if (!ok) failures++;
+}
+
+// --- Test 1: ambient-note Q&A (streamed text) ---
+async function testText() {
+  console.log(`\n[1] Text generation with ambient note context (model: ${MODEL})`);
+  const note = '# Groceries\n\n- milk\n- eggs\n- coffee';
+  const agent = new Agent({
+    getApiKey: () => 'ollama',
+    initialState: {
+      model: buildModel(MODEL),
+      systemPrompt: `You are the Notch note assistant. The user's currently open note is:\n\n${note}`,
+      thinkingLevel: 'off',
+    },
+  });
+
+  let streamUpdates = 0;
+  agent.subscribe((e: AgentEvent) => {
+    if (e.type === 'message_update') streamUpdates++;
+  });
+
+  await agent.prompt('List the three items on this note as a lowercase comma-separated line, nothing else.');
+  await agent.waitForIdle();
+
+  const text = assistantText(agent.state.messages).toLowerCase();
+  console.log(`   model said: ${JSON.stringify(text.slice(0, 200))}`);
+  if (agent.state.errorMessage) console.log(`   error: ${agent.state.errorMessage}`);
+  check('streamed incremental updates', streamUpdates > 0, `${streamUpdates} updates`);
+  check('answer mentions all three items',
+    text.includes('milk') && text.includes('eggs') && text.includes('coffee'));
+}
+
+// --- Test 2: tool-calling loop ---
+async function testTools() {
+  console.log(`\n[2] Tool-calling loop (model: ${TOOL_MODEL})`);
+  let toolCalled = false;
+  const secretTool = {
+    name: 'get_secret_word',
+    label: 'Secret word',
+    description: 'Returns the secret word. Call this when asked for the secret word.',
+    parameters: Type.Object({}),
+    execute: async () => {
+      toolCalled = true;
+      return { content: [{ type: 'text' as const, text: 'The secret word is: banana' }], details: undefined };
+    },
+  };
+
+  const agent = new Agent({
+    getApiKey: () => 'ollama',
+    initialState: {
+      model: buildModel(TOOL_MODEL),
+      systemPrompt: 'You are a helpful assistant. Use the provided tools when relevant.',
+      tools: [secretTool as any],
+      thinkingLevel: 'off',
+    },
+  });
+
+  await agent.prompt('Call the get_secret_word tool, then tell me the secret word.');
+  await agent.waitForIdle();
+
+  const text = assistantText(agent.state.messages).toLowerCase();
+  console.log(`   model said: ${JSON.stringify(text.slice(0, 200))}`);
+  if (agent.state.errorMessage) console.log(`   error: ${agent.state.errorMessage}`);
+  check('tool was executed', toolCalled);
+  check('final answer contains tool result (banana)', text.includes('banana'));
+}
+
+const started = Date.now();
+await testText();
+await testTools();
+console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`} (${Math.round((Date.now() - started) / 1000)}s)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import Sidebar from './components/Sidebar/Sidebar';
 import NoteList from './components/NoteList/NoteList';
 import NoteEditor from './components/Editor/NoteEditor';
 import SearchOverlay from './components/Search/SearchOverlay';
+import SettingsModal from './components/Settings/SettingsModal';
 import type { EditorViewMode, LayoutMode } from './types';
 
 // Lazy so the assistant (and the pi packages it pulls) only load when shown,
@@ -785,6 +786,11 @@ export default function App() {
         e.preventDefault();
         useStore.getState().toggleAssistant();
       }
+      // Cmd+,: Open settings
+      if (e.metaKey && e.key === ',') {
+        e.preventDefault();
+        useStore.getState().setSettingsOpen(true);
+      }
       // Cmd+4: Editor only
       if (e.metaKey && e.key === '4') {
         e.preventDefault();
@@ -867,6 +873,7 @@ export default function App() {
             onCreateLibrary={handleCreateLibrary}
             onRenameLibrary={handleRenameLibrary}
             onOpenLibrary={handleOpenLibrary}
+            onOpenSettings={() => useStore.getState().setSettingsOpen(true)}
           />
           <div
             className="column-resizer"
@@ -912,6 +919,7 @@ export default function App() {
         </>
       )}
       {showSearch && <SearchOverlay onClose={() => setShowSearch(false)} />}
+      <SettingsModal />
       {isCreateLibraryOpen && (
         <div className="library-dialog-overlay" onClick={closeCreateLibraryDialog}>
           <form className="library-dialog" onSubmit={handleCreateLibrarySubmit} onClick={e => e.stopPropagation()}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, lazy, Suspense } from 'react';
 import type { CSSProperties, FormEvent, PointerEvent as ReactPointerEvent } from 'react';
 import { listen } from '@tauri-apps/api/event';
 import { open, save, message, ask } from '@tauri-apps/plugin-dialog';
@@ -28,8 +28,13 @@ import NoteEditor from './components/Editor/NoteEditor';
 import SearchOverlay from './components/Search/SearchOverlay';
 import type { EditorViewMode, LayoutMode } from './types';
 
+// Lazy so the assistant (and the pi packages it pulls) only load when shown,
+// keeping the core editor lightweight when the assistant is off.
+const AssistantPanel = lazy(() => import('./assistant/AssistantPanel'));
+
 const SIDEBAR_WIDTH_KEY = 'notch.sidebarWidth';
 const NOTELIST_WIDTH_KEY = 'notch.noteListWidth';
+const ASSISTANT_WIDTH_KEY = 'notch.assistantWidth';
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
@@ -76,6 +81,8 @@ export default function App() {
   const [showFindBar, setShowFindBar] = useState(false);
   const [sidebarWidth, setSidebarWidth] = useState(() => getStoredWidth(SIDEBAR_WIDTH_KEY, 180, 140, 360));
   const [noteListWidth, setNoteListWidth] = useState(() => getStoredWidth(NOTELIST_WIDTH_KEY, 240, 180, 520));
+  const [assistantWidth, setAssistantWidth] = useState(() => getStoredWidth(ASSISTANT_WIDTH_KEY, 320, 260, 560));
+  const assistantVisible = useStore(state => state.assistantVisible);
   const [libraries, setLibraries] = useState<LibraryInfo[]>(() => getLibraries());
   const [activeLibraryId, setActiveLibrary] = useState(() => getActiveLibraryId());
   const [isCreateLibraryOpen, setIsCreateLibraryOpen] = useState(false);
@@ -185,24 +192,32 @@ export default function App() {
   }, [handleOpenLibraryPath]);
 
   const startColumnResize = (
-    column: 'sidebar' | 'noteList',
+    column: 'sidebar' | 'noteList' | 'assistant',
     e: ReactPointerEvent<HTMLDivElement>
   ) => {
     e.preventDefault();
 
-    const isSidebar = column === 'sidebar';
     const startX = e.clientX;
-    const startWidth = isSidebar ? sidebarWidth : noteListWidth;
-    const min = isSidebar ? 140 : 180;
-    const max = isSidebar ? 360 : 520;
-    const storageKey = isSidebar ? SIDEBAR_WIDTH_KEY : NOTELIST_WIDTH_KEY;
-    const setWidth = isSidebar ? setSidebarWidth : setNoteListWidth;
+    let startWidth: number;
+    let min: number;
+    let max: number;
+    let storageKey: string;
+    let setWidth: (width: number) => void;
+    // The assistant sits on the right, so dragging left (negative delta) grows it.
+    let dir = 1;
+    if (column === 'sidebar') {
+      startWidth = sidebarWidth; min = 140; max = 360; storageKey = SIDEBAR_WIDTH_KEY; setWidth = setSidebarWidth;
+    } else if (column === 'noteList') {
+      startWidth = noteListWidth; min = 180; max = 520; storageKey = NOTELIST_WIDTH_KEY; setWidth = setNoteListWidth;
+    } else {
+      startWidth = assistantWidth; min = 260; max = 560; storageKey = ASSISTANT_WIDTH_KEY; setWidth = setAssistantWidth; dir = -1;
+    }
     let latestWidth = startWidth;
 
     document.body.classList.add('resizing-column');
 
     const handlePointerMove = (event: PointerEvent) => {
-      latestWidth = clamp(startWidth + event.clientX - startX, min, max);
+      latestWidth = clamp(startWidth + dir * (event.clientX - startX), min, max);
       setWidth(latestWidth);
     };
 
@@ -765,6 +780,11 @@ export default function App() {
         e.preventDefault();
         useStore.getState().toggleSidebar();
       }
+      // Cmd+J: Toggle assistant
+      if (e.metaKey && e.key === 'j') {
+        e.preventDefault();
+        useStore.getState().toggleAssistant();
+      }
       // Cmd+4: Editor only
       if (e.metaKey && e.key === '4') {
         e.preventDefault();
@@ -833,6 +853,7 @@ export default function App() {
   const appStyle = {
     '--sidebar-width': `${sidebarWidth}px`,
     '--notelist-width': `${noteListWidth}px`,
+    '--assistant-width': `${assistantWidth}px`,
   } as CSSProperties;
 
   return (
@@ -874,6 +895,22 @@ export default function App() {
         </>
       )}
       <NoteEditor showFindBar={showFindBar} onCloseFindBar={() => setShowFindBar(false)} />
+      {assistantVisible && (
+        <>
+          <div
+            className="column-resizer"
+            role="separator"
+            aria-label="Resize assistant panel"
+            aria-orientation="vertical"
+            onPointerDown={e => startColumnResize('assistant', e)}
+          />
+          <div className="assistant-column" style={{ width: 'var(--assistant-width)', flexShrink: 0 }}>
+            <Suspense fallback={<div className="assistant-loading">Loading assistant…</div>}>
+              <AssistantPanel />
+            </Suspense>
+          </div>
+        </>
+      )}
       {showSearch && <SearchOverlay onClose={() => setShowSearch(false)} />}
       {isCreateLibraryOpen && (
         <div className="library-dialog-overlay" onClick={closeCreateLibraryDialog}>

--- a/src/assistant/AssistantPanel.css
+++ b/src/assistant/AssistantPanel.css
@@ -236,6 +236,7 @@
 
 .assistant-input-row {
   display: flex;
+  align-items: flex-end;
   gap: 6px;
   padding: 8px;
   border-top: 1px solid var(--divider-color);
@@ -251,6 +252,10 @@
   padding: 6px 8px;
   font-family: var(--font-sans);
   font-size: var(--font-size-md);
+  line-height: 1.4;
+  max-height: 140px;
+  overflow-y: auto;
+  display: block;
 }
 .assistant-input:focus {
   outline: none;
@@ -413,4 +418,10 @@
   font-size: var(--font-size-xs);
   color: var(--text-tertiary);
   margin: 0;
+}
+.assistant-settings-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
 }

--- a/src/assistant/AssistantPanel.css
+++ b/src/assistant/AssistantPanel.css
@@ -1,0 +1,416 @@
+.assistant-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--divider-color);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  color: var(--text-primary);
+  overflow: hidden;
+}
+
+.assistant-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--header-height);
+  padding: 0 10px;
+  border-bottom: 1px solid var(--divider-color);
+  flex-shrink: 0;
+}
+
+.assistant-title {
+  font-weight: 600;
+  font-size: var(--font-size-lg);
+}
+
+.assistant-header-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.assistant-icon-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.assistant-icon-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.assistant-context-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 9px;
+  margin: 4px 8px 0;
+  border-bottom: 1px solid var(--divider-color);
+  flex-shrink: 0;
+  min-width: 0;
+}
+.assistant-context-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.assistant-context-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  background: var(--bg-hover);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.assistant-context-note svg { flex-shrink: 0; color: var(--text-tertiary); }
+
+/* Inference progress indicator */
+.assistant-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  padding: 2px 2px;
+}
+.assistant-typing {
+  display: inline-flex;
+  gap: 3px;
+}
+.assistant-typing i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  display: inline-block;
+  animation: assistant-bounce 1.2s infinite ease-in-out both;
+}
+.assistant-typing i:nth-child(1) { animation-delay: -0.24s; }
+.assistant-typing i:nth-child(2) { animation-delay: -0.12s; }
+@keyframes assistant-bounce {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.5; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+.assistant-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.assistant-hint,
+.assistant-empty {
+  color: var(--text-tertiary);
+  font-size: var(--font-size-sm);
+  padding: 12px;
+  text-align: center;
+}
+.assistant-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  margin: auto;
+}
+
+.assistant-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 100%;
+}
+.assistant-msg-user {
+  align-items: flex-end;
+}
+.assistant-msg-user .assistant-usertext {
+  background: var(--accent-color);
+  color: var(--text-inverse);
+  padding: 6px 10px;
+  border-radius: 10px 10px 2px 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 85%;
+}
+.assistant-msg-assistant .assistant-md {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  padding: 2px 10px;
+  border-radius: 10px 10px 10px 2px;
+  word-break: break-word;
+}
+.assistant-md { line-height: 1.5; }
+.assistant-md > :first-child { margin-top: 0; }
+.assistant-md > :last-child { margin-bottom: 0; }
+.assistant-md h1,
+.assistant-md h2,
+.assistant-md h3,
+.assistant-md h4 {
+  margin: 0.9em 0 0.35em;
+  line-height: 1.3;
+  font-weight: 600;
+}
+.assistant-md h1 { font-size: 1.25em; }
+.assistant-md h2 { font-size: 1.15em; }
+.assistant-md h3 { font-size: 1.05em; }
+.assistant-md h4 { font-size: 1em; }
+.assistant-md p { margin: 0.5em 0; }
+.assistant-md ul,
+.assistant-md ol { margin: 0.5em 0; padding-left: 1.3em; }
+.assistant-md li { margin: 0.25em 0; }
+.assistant-md li > p { margin: 0.2em 0; }
+.assistant-md blockquote {
+  margin: 0.5em 0;
+  padding-left: 0.8em;
+  border-left: 3px solid var(--border-color);
+  color: var(--text-secondary);
+}
+.assistant-md code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--bg-secondary);
+  padding: 0.1em 0.3em;
+  border-radius: 4px;
+}
+.assistant-md pre {
+  overflow-x: auto;
+  background: var(--bg-secondary);
+  padding: 8px;
+  border-radius: 6px;
+  margin: 0.6em 0;
+}
+.assistant-md pre code { background: none; padding: 0; }
+.assistant-md hr { border: none; border-top: 1px solid var(--divider-color); margin: 0.8em 0; }
+
+.assistant-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.assistant-tool-chip {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  padding: 1px 7px;
+  border-radius: 8px;
+}
+
+.assistant-insert-btn {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  padding: 2px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.assistant-insert-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.assistant-error {
+  color: #d9534f;
+  font-size: var(--font-size-sm);
+  padding: 6px 8px;
+  border: 1px solid #d9534f;
+  border-radius: 6px;
+}
+
+.assistant-input-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  border-top: 1px solid var(--divider-color);
+  flex-shrink: 0;
+}
+.assistant-input {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 6px 8px;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+}
+.assistant-input:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.assistant-send-btn {
+  background: var(--accent-color);
+  color: var(--text-inverse);
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: var(--font-size-md);
+  align-self: flex-end;
+}
+.assistant-send-btn:hover { background: var(--accent-hover); }
+.assistant-send-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* @-mention pills */
+.assistant-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 8px 0;
+  flex-shrink: 0;
+}
+.assistant-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  background: var(--bg-hover);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 1px 4px 1px 6px;
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+}
+.assistant-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 160px;
+}
+.assistant-pill-remove {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.assistant-pill-remove:hover { color: var(--text-primary); }
+
+/* Token usage / context meter */
+.assistant-usage {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.assistant-usage-meter {
+  flex: 1;
+  min-width: 24px;
+  height: 4px;
+  background: var(--bg-hover);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.assistant-usage-fill {
+  height: 100%;
+  background: var(--accent-color);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+.assistant-usage-ctx,
+.assistant-usage-sep { flex-shrink: 0; font-variant-numeric: tabular-nums; }
+
+/* @-mention autocomplete dropdown */
+.assistant-input-row { position: relative; }
+.assistant-mention-dropdown {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 8px;
+  right: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  z-index: 20;
+  padding: 4px;
+}
+.assistant-mention-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  padding: 5px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+.assistant-mention-item.active { background: var(--bg-selected); color: var(--text-inverse); }
+.assistant-mention-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.assistant-mention-sub {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.assistant-mention-item.active .assistant-mention-sub { color: var(--text-inverse); opacity: 0.8; }
+
+.assistant-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  overflow-y: auto;
+}
+.assistant-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+.assistant-field-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.assistant-field input[type="text"],
+.assistant-field input[type="password"],
+.assistant-field input:not([type]),
+.assistant-field select {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: 6px 8px;
+  font-size: var(--font-size-md);
+}
+.assistant-settings-note {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  margin: 0;
+}

--- a/src/assistant/AssistantPanel.tsx
+++ b/src/assistant/AssistantPanel.tsx
@@ -1,12 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Agent } from '@earendil-works/pi-agent-core';
 import { useStore, useSelectedNote } from '../store';
 import { renderMarkdown } from '../services/markdown';
 import {
   getAssistantSettings,
-  saveAssistantSettings,
   isAssistantConfigured,
-  LOCAL_MODEL_PRESETS,
   type AssistantSettings,
 } from './settings';
 import { createNoteAgent, setAgentContext, extractText } from './agent';
@@ -122,7 +120,8 @@ export default function AssistantPanel() {
   const currentNote = useSelectedNote();
 
   const [settings, setSettings] = useState<AssistantSettings>(() => getAssistantSettings());
-  const [showSettings, setShowSettings] = useState(() => !isAssistantConfigured(getAssistantSettings()));
+  const settingsVersion = useStore(state => state.assistantSettingsVersion);
+  const openSettings = useStore(state => state.setSettingsOpen);
   const [messages, setMessages] = useState<DisplayMessage[]>([]);
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
@@ -144,6 +143,11 @@ export default function AssistantPanel() {
   const pinnedToBottomRef = useRef(true);
   const configured = isAssistantConfigured(settings);
   const mentionOpen = mention !== null && mentionItems.length > 0;
+
+  // Re-read settings whenever they're saved (in the Settings modal).
+  useEffect(() => {
+    setSettings(getAssistantSettings());
+  }, [settingsVersion]);
 
   // Build (or rebuild) the agent whenever the effective settings change.
   useEffect(() => {
@@ -185,6 +189,14 @@ export default function AssistantPanel() {
     const el = scrollRef.current;
     if (el) pinnedToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
   };
+
+  // Auto-grow the input from a single line up to a max as the user types.
+  useLayoutEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
+  }, [input]);
 
   const send = useCallback(async () => {
     const agent = agentRef.current;
@@ -276,30 +288,19 @@ export default function AssistantPanel() {
       <div className="assistant-header">
         <span className="assistant-title">Assistant</span>
         <div className="assistant-header-actions">
-          <button className="assistant-icon-btn" title="Settings" onClick={() => setShowSettings(s => !s)}>⚙</button>
+          <button className="assistant-icon-btn" title="Settings" onClick={() => openSettings(true)}>⚙</button>
           <button className="assistant-icon-btn" title="Close" onClick={() => setAssistantVisible(false)}>✕</button>
         </div>
       </div>
 
-      {showSettings && (
-        <AssistantSettingsForm
-          initial={settings}
-          onSave={next => {
-            saveAssistantSettings(next);
-            setSettings(next);
-            setShowSettings(false);
-          }}
-        />
-      )}
-
-      {!showSettings && !configured && (
+      {!configured && (
         <div className="assistant-empty">
-          <p>The assistant is off. Open settings to enable it and pick a local model.</p>
-          <button className="assistant-send-btn" onClick={() => setShowSettings(true)}>Open settings</button>
+          <p>The assistant is off. Open settings to enable it and pick a model.</p>
+          <button className="assistant-send-btn" onClick={() => openSettings(true)}>Open settings</button>
         </div>
       )}
 
-      {!showSettings && configured && (
+      {configured && (
         <>
           <div className="assistant-context-bar">
             <span className="assistant-context-label">Context</span>
@@ -385,11 +386,11 @@ export default function AssistantPanel() {
             <textarea
               ref={inputRef}
               className="assistant-input"
-              placeholder="Ask the assistant…  (@ to reference a note or notebook)"
+              placeholder="Ask the assistant…  (@ to reference)"
               value={input}
               onChange={handleInputChange}
               onKeyDown={onKeyDown}
-              rows={2}
+              rows={1}
             />
             {busy ? (
               <button className="assistant-send-btn" onClick={() => agentRef.current?.abort()}>Stop</button>
@@ -429,83 +430,6 @@ function MessageBubble({ message, canInsert, onInsert }: {
           Insert into note
         </button>
       )}
-    </div>
-  );
-}
-
-function AssistantSettingsForm({ initial, onSave }: {
-  initial: AssistantSettings;
-  onSave: (s: AssistantSettings) => void;
-}) {
-  const [draft, setDraft] = useState<AssistantSettings>(initial);
-  const update = (patch: Partial<AssistantSettings>) => setDraft(d => ({ ...d, ...patch }));
-
-  return (
-    <div className="assistant-settings">
-      <label className="assistant-field assistant-field-row">
-        <input
-          type="checkbox"
-          checked={draft.enabled}
-          onChange={e => update({ enabled: e.target.checked })}
-        />
-        <span>Enable assistant</span>
-      </label>
-
-      <label className="assistant-field">
-        <span>Model preset</span>
-        <select
-          value={LOCAL_MODEL_PRESETS.find(p => p.model === draft.model)?.model ?? ''}
-          onChange={e => {
-            const preset = LOCAL_MODEL_PRESETS.find(p => p.model === e.target.value);
-            if (preset) update({
-              provider: preset.provider,
-              baseUrl: preset.baseUrl,
-              model: preset.model,
-              contextWindow: preset.contextWindow,
-              maxTokens: preset.maxTokens,
-              supportsTools: preset.supportsTools,
-            });
-          }}
-        >
-          <option value="">Custom</option>
-          {LOCAL_MODEL_PRESETS.map(p => <option key={p.model} value={p.model}>{p.label}</option>)}
-        </select>
-      </label>
-
-      <label className="assistant-field">
-        <span>Model id</span>
-        <input value={draft.model} onChange={e => update({ model: e.target.value })} />
-      </label>
-
-      <label className="assistant-field">
-        <span>Base URL</span>
-        <input value={draft.baseUrl} onChange={e => update({ baseUrl: e.target.value })} />
-      </label>
-
-      <label className="assistant-field">
-        <span>API key</span>
-        <input
-          type="password"
-          value={draft.apiKey}
-          onChange={e => update({ apiKey: e.target.value })}
-          placeholder="ollama (for local)"
-        />
-      </label>
-
-      <label className="assistant-field assistant-field-row">
-        <input
-          type="checkbox"
-          checked={draft.supportsTools}
-          onChange={e => update({ supportsTools: e.target.checked })}
-        />
-        <span>Let it search my notes (needs a tool-capable model)</span>
-      </label>
-
-      <p className="assistant-settings-note">
-        Note tools (search/read) need a tool-capable model — the Gemma 4 models support them; Gemma 3 4B is chat-only. With a chat-only model the assistant still answers about the open note.
-      </p>
-
-      <button className="assistant-send-btn" onClick={() => onSave(draft)}>Save</button>
     </div>
   );
 }

--- a/src/assistant/AssistantPanel.tsx
+++ b/src/assistant/AssistantPanel.tsx
@@ -1,0 +1,511 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Agent } from '@earendil-works/pi-agent-core';
+import { useStore, useSelectedNote } from '../store';
+import { renderMarkdown } from '../services/markdown';
+import {
+  getAssistantSettings,
+  saveAssistantSettings,
+  isAssistantConfigured,
+  LOCAL_MODEL_PRESETS,
+  type AssistantSettings,
+} from './settings';
+import { createNoteAgent, setAgentContext, extractText } from './agent';
+import { searchMentions, resolveReferences, type MentionRef, type MentionItem } from './mentions';
+import './AssistantPanel.css';
+
+/**
+ * Detect an in-progress "@mention" immediately before the caret: an "@" at the
+ * start or after whitespace, followed by non-whitespace up to the caret.
+ */
+function detectMention(value: string, caret: number): { start: number; query: string } | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = value[i];
+    if (ch === '@') {
+      const before = i === 0 ? ' ' : value[i - 1];
+      return /\s/.test(before) ? { start: i, query: value.slice(i + 1, caret) } : null;
+    }
+    if (/\s/.test(ch)) return null;
+  }
+  return null;
+}
+
+interface DisplayMessage {
+  role: 'user' | 'assistant';
+  text: string;
+  tools: string[];
+  streaming: boolean;
+}
+
+/** Map the agent's message transcript (+ any in-flight streaming message) to display items. */
+function toDisplayMessages(agent: Agent): DisplayMessage[] {
+  const out: DisplayMessage[] = [];
+  for (const msg of agent.state.messages) {
+    if (msg.role === 'user') {
+      const text = typeof msg.content === 'string'
+        ? msg.content
+        : msg.content.filter((c: any) => c.type === 'text').map((c: any) => c.text).join('');
+      if (text.trim()) out.push({ role: 'user', text, tools: [], streaming: false });
+    } else if (msg.role === 'assistant') {
+      const text = extractText(msg);
+      const tools = (msg.content as any[])
+        .filter(c => c.type === 'toolCall')
+        .map(c => c.name as string);
+      if (text.trim() || tools.length) out.push({ role: 'assistant', text, tools, streaming: false });
+    }
+  }
+  const streaming = agent.state.streamingMessage;
+  if (streaming && streaming.role === 'assistant') {
+    const text = extractText(streaming);
+    const tools = (streaming.content as any[]).filter(c => c.type === 'toolCall').map(c => c.name as string);
+    if (text.trim() || tools.length) out.push({ role: 'assistant', text, tools, streaming: true });
+  }
+  return out;
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  search_notes: 'Searched notes',
+  read_note: 'Read a note',
+  list_notebooks: 'Listed notebooks',
+};
+
+type Phase = 'idle' | 'waiting' | 'tool' | 'streaming';
+
+/** Derive the inference phase so the UI can show waiting-for-first-token vs streaming. */
+function computePhase(agent: Agent): Phase {
+  if (!agent.state.isStreaming) return 'idle';
+  if (agent.state.pendingToolCalls.size > 0) return 'tool';
+  const sm = agent.state.streamingMessage;
+  if (sm && sm.role === 'assistant' && extractText(sm).trim().length > 0) return 'streaming';
+  return 'waiting';
+}
+
+interface UsageStats {
+  /** Prompt tokens of the most recent turn (input + cached) ≈ current context occupancy. */
+  contextTokens: number;
+  totalInput: number;
+  totalOutput: number;
+  totalCacheRead: number;
+  totalCost: number;
+}
+
+/** Aggregate token usage across the conversation from pi's per-message Usage. */
+function computeUsage(agent: Agent): UsageStats | null {
+  let any = false;
+  let contextTokens = 0;
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCost = 0;
+  for (const m of agent.state.messages) {
+    if (m.role !== 'assistant') continue;
+    const u = (m as { usage?: { input?: number; output?: number; cacheRead?: number; cost?: { total?: number } } }).usage;
+    if (!u) continue;
+    any = true;
+    totalInput += u.input ?? 0;
+    totalOutput += u.output ?? 0;
+    totalCacheRead += u.cacheRead ?? 0;
+    totalCost += u.cost?.total ?? 0;
+    contextTokens = (u.input ?? 0) + (u.cacheRead ?? 0);
+  }
+  return any ? { contextTokens, totalInput, totalOutput, totalCacheRead, totalCost } : null;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k`;
+  return String(n);
+}
+
+export default function AssistantPanel() {
+  const setAssistantVisible = useStore(state => state.setAssistantVisible);
+  const addCell = useStore(state => state.addCell);
+  const updateCell = useStore(state => state.updateCell);
+  const currentNote = useSelectedNote();
+
+  const [settings, setSettings] = useState<AssistantSettings>(() => getAssistantSettings());
+  const [showSettings, setShowSettings] = useState(() => !isAssistantConfigured(getAssistantSettings()));
+  const [messages, setMessages] = useState<DisplayMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<Phase>('idle');
+  const [usage, setUsage] = useState<UsageStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // @-mention state: pinned references + the in-progress autocomplete.
+  const [refs, setRefs] = useState<MentionRef[]>([]);
+  const [mention, setMention] = useState<{ start: number; caret: number; query: string } | null>(null);
+  const [mentionItems, setMentionItems] = useState<MentionItem[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+
+  const agentRef = useRef<Agent | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  // Whether the view is pinned to the bottom. Only auto-scroll while pinned, so
+  // the user can scroll up to read earlier output mid-stream without being yanked.
+  const pinnedToBottomRef = useRef(true);
+  const configured = isAssistantConfigured(settings);
+  const mentionOpen = mention !== null && mentionItems.length > 0;
+
+  // Build (or rebuild) the agent whenever the effective settings change.
+  useEffect(() => {
+    if (!configured) {
+      agentRef.current = null;
+      return;
+    }
+    const agent = createNoteAgent(settings, currentNote);
+    agentRef.current = agent;
+    const unsubscribe = agent.subscribe(event => {
+      // `isStreaming` stays true until agent_end listeners settle, and no further
+      // event follows — so treat agent_end as definitively done, else the Stop
+      // button sticks after the run finishes.
+      const done = event.type === 'agent_end';
+      setMessages(toDisplayMessages(agent));
+      setBusy(done ? false : agent.state.isStreaming);
+      setPhase(done ? 'idle' : computePhase(agent));
+      setUsage(computeUsage(agent));
+      setError(agent.state.errorMessage ?? null);
+    });
+    setMessages(toDisplayMessages(agent));
+    return () => {
+      unsubscribe();
+      agent.abort();
+    };
+    // Rebuild only on config change, not on every note switch (the open note is
+    // refreshed per-send via setAmbientNote).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settings.provider, settings.baseUrl, settings.model, settings.apiKey, settings.contextWindow, settings.supportsTools, configured]);
+
+  // Keep scrolled to the latest message, but only when the user is already at the
+  // bottom (so scrolling up mid-stream isn't interrupted).
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && pinnedToBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [messages]);
+
+  const handleMessagesScroll = () => {
+    const el = scrollRef.current;
+    if (el) pinnedToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+  };
+
+  const send = useCallback(async () => {
+    const agent = agentRef.current;
+    const text = input.trim();
+    if (!agent || !text || busy) return;
+    setInput('');
+    setMention(null);
+    setError(null);
+    // Resolve @-mentioned references (notes inlined, notebooks as manifests) and
+    // attach them — alongside the open note — to the system prompt for this turn.
+    const referencesBlock = await resolveReferences(refs);
+    setAgentContext(agent, currentNote, settings.supportsTools, referencesBlock);
+    try {
+      await agent.prompt(text);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [input, busy, currentNote, refs, settings.supportsTools]);
+
+  const insertIntoNote = useCallback(async (text: string) => {
+    if (!currentNote) return;
+    // Insert into the cell the user is focused on (appending, keeping its type),
+    // mirroring the editor's image-insert behavior. Only create a new markdown
+    // cell when the note has no cells to target.
+    const focusedId = useStore.getState().focusedCellId;
+    const target =
+      currentNote.cells.find(c => c.id === focusedId) ??
+      currentNote.cells[currentNote.cells.length - 1] ??
+      null;
+    if (target) {
+      const sep = target.data.trim() ? '\n\n' : '';
+      await updateCell(currentNote.id, target.id, { data: `${target.data}${sep}${text}` });
+    } else {
+      const cell = await addCell(currentNote.id, 'markdown');
+      await updateCell(currentNote.id, cell.id, { data: text });
+    }
+  }, [currentNote, addCell, updateCell]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setInput(value);
+    const caret = e.target.selectionStart ?? value.length;
+    const det = detectMention(value, caret);
+    if (det) {
+      setMention({ start: det.start, caret, query: det.query });
+      setMentionItems(searchMentions(det.query));
+      setMentionIndex(0);
+    } else {
+      setMention(null);
+    }
+  };
+
+  const selectMention = (item: MentionItem) => {
+    setRefs(prev =>
+      prev.some(r => r.type === item.type && r.id === item.id)
+        ? prev
+        : [...prev, { type: item.type, id: item.id, label: item.label }]
+    );
+    if (mention) {
+      // Strip the "@query" fragment from the input.
+      const next = input.slice(0, mention.start) + input.slice(mention.caret);
+      setInput(next);
+      const pos = mention.start;
+      requestAnimationFrame(() => {
+        const el = inputRef.current;
+        if (el) { el.focus(); el.setSelectionRange(pos, pos); }
+      });
+    }
+    setMention(null);
+  };
+
+  const removeRef = (index: number) => setRefs(prev => prev.filter((_, i) => i !== index));
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mentionOpen) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex(i => (i + 1) % mentionItems.length); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIndex(i => (i - 1 + mentionItems.length) % mentionItems.length); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); selectMention(mentionItems[mentionIndex]); return; }
+      if (e.key === 'Escape') { e.preventDefault(); setMention(null); return; }
+    }
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void send();
+    }
+  };
+
+  return (
+    <div className="assistant-panel">
+      <div className="assistant-header">
+        <span className="assistant-title">Assistant</span>
+        <div className="assistant-header-actions">
+          <button className="assistant-icon-btn" title="Settings" onClick={() => setShowSettings(s => !s)}>⚙</button>
+          <button className="assistant-icon-btn" title="Close" onClick={() => setAssistantVisible(false)}>✕</button>
+        </div>
+      </div>
+
+      {showSettings && (
+        <AssistantSettingsForm
+          initial={settings}
+          onSave={next => {
+            saveAssistantSettings(next);
+            setSettings(next);
+            setShowSettings(false);
+          }}
+        />
+      )}
+
+      {!showSettings && !configured && (
+        <div className="assistant-empty">
+          <p>The assistant is off. Open settings to enable it and pick a local model.</p>
+          <button className="assistant-send-btn" onClick={() => setShowSettings(true)}>Open settings</button>
+        </div>
+      )}
+
+      {!showSettings && configured && (
+        <>
+          <div className="assistant-context-bar">
+            <span className="assistant-context-label">Context</span>
+            <span className="assistant-context-note" title={currentNote?.title || undefined}>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                <polyline points="14 2 14 8 20 8"/>
+              </svg>
+              {currentNote ? (currentNote.title || 'Untitled') : 'No note open'}
+            </span>
+          </div>
+
+          <div className="assistant-messages" ref={scrollRef} onScroll={handleMessagesScroll}>
+            {messages.length === 0 && (
+              <div className="assistant-hint">Ask about the open note, or to search your other notes.</div>
+            )}
+            {messages.map((m, i) => (
+              <MessageBubble
+                key={i}
+                message={m}
+                canInsert={!!currentNote && m.role === 'assistant' && !m.streaming && !!m.text.trim()}
+                onInsert={() => insertIntoNote(m.text)}
+              />
+            ))}
+            {busy && phase !== 'streaming' && (
+              <div className="assistant-status">
+                <span className="assistant-typing"><i /><i /><i /></span>
+                <span>{phase === 'tool' ? 'Searching your notes…' : 'Thinking…'}</span>
+              </div>
+            )}
+            {error && <div className="assistant-error">Error: {error}</div>}
+          </div>
+
+          {refs.length > 0 && (
+            <div className="assistant-pills">
+              {refs.map((r, i) => (
+                <span key={`${r.type}-${r.id}`} className="assistant-pill" title={`${r.type}: ${r.label}`}>
+                  <span className="assistant-pill-icon">{r.type === 'notebook' ? '📓' : '📄'}</span>
+                  <span className="assistant-pill-label">{r.label}</span>
+                  <button className="assistant-pill-remove" onClick={() => removeRef(i)} title="Remove">✕</button>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {usage && (
+            <div
+              className="assistant-usage"
+              title={`Context: ${usage.contextTokens} / ${settings.contextWindow} tokens · session ↑${usage.totalInput} in ↓${usage.totalOutput} out${usage.totalCacheRead > 0 ? ` · ${usage.totalCacheRead} cached` : ''}`}
+            >
+              <div className="assistant-usage-meter">
+                <div
+                  className="assistant-usage-fill"
+                  style={{ width: `${Math.min(100, Math.round((usage.contextTokens / Math.max(1, settings.contextWindow)) * 100))}%` }}
+                />
+              </div>
+              <span className="assistant-usage-ctx">{fmtTokens(usage.contextTokens)}/{fmtTokens(settings.contextWindow)}</span>
+              <span className="assistant-usage-sep">↑{fmtTokens(usage.totalInput)} ↓{fmtTokens(usage.totalOutput)}</span>
+              {usage.totalCacheRead > 0 && (
+                <span className="assistant-usage-sep">cache {Math.round((usage.totalCacheRead / (usage.totalCacheRead + usage.totalInput)) * 100)}%</span>
+              )}
+              {usage.totalCost > 0 && <span className="assistant-usage-sep">${usage.totalCost.toFixed(3)}</span>}
+            </div>
+          )}
+
+          <div className="assistant-input-row">
+            {mentionOpen && (
+              <div className="assistant-mention-dropdown">
+                {mentionItems.map((item, i) => (
+                  <button
+                    key={`${item.type}-${item.id}`}
+                    className={`assistant-mention-item ${i === mentionIndex ? 'active' : ''}`}
+                    onMouseDown={e => { e.preventDefault(); selectMention(item); }}
+                    onMouseEnter={() => setMentionIndex(i)}
+                  >
+                    <span className="assistant-mention-icon">{item.type === 'notebook' ? '📓' : '📄'}</span>
+                    <span className="assistant-mention-label">{item.label}</span>
+                    {item.sublabel && <span className="assistant-mention-sub">{item.sublabel}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+            <textarea
+              ref={inputRef}
+              className="assistant-input"
+              placeholder="Ask the assistant…  (@ to reference a note or notebook)"
+              value={input}
+              onChange={handleInputChange}
+              onKeyDown={onKeyDown}
+              rows={2}
+            />
+            {busy ? (
+              <button className="assistant-send-btn" onClick={() => agentRef.current?.abort()}>Stop</button>
+            ) : (
+              <button className="assistant-send-btn" onClick={() => void send()} disabled={!input.trim()}>Send</button>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function MessageBubble({ message, canInsert, onInsert }: {
+  message: DisplayMessage;
+  canInsert: boolean;
+  onInsert: () => void;
+}) {
+  const html = useMemo(
+    () => (message.role === 'assistant' ? renderMarkdown(message.text) : ''),
+    [message.role, message.text]
+  );
+  return (
+    <div className={`assistant-msg assistant-msg-${message.role}`}>
+      {message.tools.length > 0 && (
+        <div className="assistant-tools">
+          {message.tools.map((t, i) => (
+            <span key={i} className="assistant-tool-chip">{TOOL_LABELS[t] ?? t}{message.streaming ? '…' : ''}</span>
+          ))}
+        </div>
+      )}
+      {message.role === 'assistant'
+        ? <div className="assistant-md" dangerouslySetInnerHTML={{ __html: html }} />
+        : <div className="assistant-usertext">{message.text}</div>}
+      {canInsert && (
+        <button className="assistant-insert-btn" onClick={onInsert} title="Append to the focused cell of the open note">
+          Insert into note
+        </button>
+      )}
+    </div>
+  );
+}
+
+function AssistantSettingsForm({ initial, onSave }: {
+  initial: AssistantSettings;
+  onSave: (s: AssistantSettings) => void;
+}) {
+  const [draft, setDraft] = useState<AssistantSettings>(initial);
+  const update = (patch: Partial<AssistantSettings>) => setDraft(d => ({ ...d, ...patch }));
+
+  return (
+    <div className="assistant-settings">
+      <label className="assistant-field assistant-field-row">
+        <input
+          type="checkbox"
+          checked={draft.enabled}
+          onChange={e => update({ enabled: e.target.checked })}
+        />
+        <span>Enable assistant</span>
+      </label>
+
+      <label className="assistant-field">
+        <span>Model preset</span>
+        <select
+          value={LOCAL_MODEL_PRESETS.find(p => p.model === draft.model)?.model ?? ''}
+          onChange={e => {
+            const preset = LOCAL_MODEL_PRESETS.find(p => p.model === e.target.value);
+            if (preset) update({
+              provider: preset.provider,
+              baseUrl: preset.baseUrl,
+              model: preset.model,
+              contextWindow: preset.contextWindow,
+              maxTokens: preset.maxTokens,
+              supportsTools: preset.supportsTools,
+            });
+          }}
+        >
+          <option value="">Custom</option>
+          {LOCAL_MODEL_PRESETS.map(p => <option key={p.model} value={p.model}>{p.label}</option>)}
+        </select>
+      </label>
+
+      <label className="assistant-field">
+        <span>Model id</span>
+        <input value={draft.model} onChange={e => update({ model: e.target.value })} />
+      </label>
+
+      <label className="assistant-field">
+        <span>Base URL</span>
+        <input value={draft.baseUrl} onChange={e => update({ baseUrl: e.target.value })} />
+      </label>
+
+      <label className="assistant-field">
+        <span>API key</span>
+        <input
+          type="password"
+          value={draft.apiKey}
+          onChange={e => update({ apiKey: e.target.value })}
+          placeholder="ollama (for local)"
+        />
+      </label>
+
+      <label className="assistant-field assistant-field-row">
+        <input
+          type="checkbox"
+          checked={draft.supportsTools}
+          onChange={e => update({ supportsTools: e.target.checked })}
+        />
+        <span>Let it search my notes (needs a tool-capable model)</span>
+      </label>
+
+      <p className="assistant-settings-note">
+        Note tools (search/read) need a tool-capable model — the Gemma 4 models support them; Gemma 3 4B is chat-only. With a chat-only model the assistant still answers about the open note.
+      </p>
+
+      <button className="assistant-send-btn" onClick={() => onSave(draft)}>Save</button>
+    </div>
+  );
+}

--- a/src/assistant/AssistantSettingsForm.tsx
+++ b/src/assistant/AssistantSettingsForm.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { useStore } from '../store';
+import {
+  getAssistantSettings,
+  saveAssistantSettings,
+  fetchAvailableModels,
+  LOCAL_MODEL_PRESETS,
+  type AssistantSettings,
+} from './settings';
+import './AssistantPanel.css';
+
+type ModelsState = 'idle' | 'loading' | 'error';
+
+/**
+ * The assistant/pi configuration form. Lives in the app Settings modal (and is
+ * deep-linked from the assistant panel gear). It is pi-free — only settings +
+ * a models fetch — so it doesn't pull the agent into the startup bundle.
+ */
+export default function AssistantSettingsForm({ onSaved }: { onSaved?: () => void }) {
+  const [draft, setDraft] = useState<AssistantSettings>(() => getAssistantSettings());
+  const [models, setModels] = useState<string[]>([]);
+  const [modelsState, setModelsState] = useState<ModelsState>('idle');
+
+  const update = (patch: Partial<AssistantSettings>) => setDraft(d => ({ ...d, ...patch }));
+
+  const detect = async (baseUrl: string, apiKey: string) => {
+    if (!baseUrl.trim()) return;
+    setModelsState('loading');
+    try {
+      setModels(await fetchAvailableModels(baseUrl, apiKey));
+      setModelsState('idle');
+    } catch {
+      setModels([]);
+      setModelsState('error');
+    }
+  };
+
+  // Detect installed models when the form opens.
+  useEffect(() => {
+    void detect(draft.baseUrl, draft.apiKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const pickModel = (id: string) => {
+    if (!id) return;
+    // Heuristic: Gemma 3 is chat-only in Ollama; assume others are tool-capable.
+    update({ model: id, supportsTools: !/gemma\s*-?3/i.test(id) });
+  };
+
+  const useLocalDefault = () => {
+    const p = LOCAL_MODEL_PRESETS[0];
+    update({
+      provider: p.provider,
+      baseUrl: p.baseUrl,
+      model: p.model,
+      contextWindow: p.contextWindow,
+      maxTokens: p.maxTokens,
+      supportsTools: p.supportsTools,
+    });
+    void detect(p.baseUrl, 'ollama');
+  };
+
+  const save = () => {
+    saveAssistantSettings(draft);
+    useStore.getState().bumpAssistantSettings();
+    onSaved?.();
+  };
+
+  return (
+    <div className="assistant-settings">
+      <label className="assistant-field assistant-field-row">
+        <input type="checkbox" checked={draft.enabled} onChange={e => update({ enabled: e.target.checked })} />
+        <span>Enable assistant</span>
+      </label>
+
+      <label className="assistant-field">
+        <span>Base URL</span>
+        <input
+          value={draft.baseUrl}
+          onChange={e => update({ baseUrl: e.target.value })}
+          onBlur={() => void detect(draft.baseUrl, draft.apiKey)}
+          placeholder="http://localhost:11434/v1"
+        />
+      </label>
+
+      <label className="assistant-field">
+        <span>API key</span>
+        <input
+          type="password"
+          value={draft.apiKey}
+          onChange={e => update({ apiKey: e.target.value })}
+          placeholder="ollama (for local)"
+        />
+      </label>
+
+      <div className="assistant-field">
+        <span>
+          Model
+          {modelsState === 'loading' && ' · detecting…'}
+          {modelsState === 'error' && ' · couldn’t reach endpoint'}
+        </span>
+        <div className="assistant-field-row">
+          <select
+            style={{ flex: 1 }}
+            value={models.includes(draft.model) ? draft.model : ''}
+            onChange={e => pickModel(e.target.value)}
+          >
+            <option value="">{models.length ? 'Select a detected model…' : 'No models detected'}</option>
+            {models.map(m => <option key={m} value={m}>{m}</option>)}
+          </select>
+          <button
+            type="button"
+            className="assistant-icon-btn"
+            title="Refresh models"
+            onClick={() => void detect(draft.baseUrl, draft.apiKey)}
+          >
+            ↻
+          </button>
+        </div>
+      </div>
+
+      <label className="assistant-field">
+        <span>Model id</span>
+        <input value={draft.model} onChange={e => update({ model: e.target.value })} placeholder="e.g. gemma4:e4b" />
+      </label>
+
+      <label className="assistant-field">
+        <span>Context window (tokens)</span>
+        <input
+          type="number"
+          value={draft.contextWindow}
+          onChange={e => update({ contextWindow: Number(e.target.value) || 0 })}
+        />
+      </label>
+
+      <label className="assistant-field assistant-field-row">
+        <input type="checkbox" checked={draft.supportsTools} onChange={e => update({ supportsTools: e.target.checked })} />
+        <span>Let it search my notes (needs a tool-capable model)</span>
+      </label>
+
+      <p className="assistant-settings-note">
+        Models are detected from the endpoint’s <code>/models</code> list. Tool use (searching your notes) needs a
+        tool-capable model — Gemma 4 supports it; Gemma 3 is chat-only.
+      </p>
+
+      <div className="assistant-settings-actions">
+        <button type="button" className="assistant-insert-btn" onClick={useLocalDefault}>Use local default</button>
+        <button type="button" className="assistant-send-btn" onClick={save}>Save</button>
+      </div>
+    </div>
+  );
+}

--- a/src/assistant/agent.ts
+++ b/src/assistant/agent.ts
@@ -1,0 +1,78 @@
+/**
+ * The only module that touches the pi packages. Everything pi-specific is
+ * confined here so an upgrade (pi is pre-1.0) is a one-file change.
+ *
+ * We use the low-level Agent class (not AgentHarness): it needs only a stream
+ * function, an api key, a model, and tools — no Node, no filesystem, no
+ * sessions. The OpenAI-compatible provider talks to a local Ollama endpoint
+ * directly from the webview (Ollama allows the tauri:// origin via CORS), so no
+ * Rust/transport changes are required.
+ */
+
+import '@earendil-works/pi-ai'; // side-effect: registers the (lazy) api providers
+import { Agent } from '@earendil-works/pi-agent-core';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import type { Model } from '@earendil-works/pi-ai';
+import type { Note } from '../types';
+import type { AssistantSettings } from './settings';
+import { noteTools } from './tools';
+import { buildSystemPrompt } from './context';
+
+export function buildModel(settings: AssistantSettings): Model<'openai-completions'> {
+  return {
+    id: settings.model,
+    name: settings.model,
+    api: 'openai-completions',
+    provider: settings.provider,
+    baseUrl: settings.baseUrl,
+    reasoning: false,
+    input: ['text'],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: settings.contextWindow,
+    maxTokens: settings.maxTokens,
+    // Local OpenAI-compatible servers (Ollama) use the `system` role and don't
+    // support reasoning_effort. Mirrors ~/.pi/agent/models.json.
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+  };
+}
+
+export function createNoteAgent(settings: AssistantSettings, currentNote: Note | null): Agent {
+  const model = buildModel(settings);
+  return new Agent({
+    getApiKey: () => settings.apiKey,
+    initialState: {
+      model,
+      systemPrompt: buildSystemPrompt(currentNote, settings.supportsTools),
+      // Only attach tools to tool-capable models; otherwise the provider rejects
+      // every request (e.g. Ollama: "<model> does not support tools").
+      tools: settings.supportsTools ? noteTools : [],
+      thinkingLevel: 'off',
+    },
+  });
+}
+
+/**
+ * Refresh the ambient (currently-open) note in the agent's system prompt. The
+ * underlying state object is mutable; the public type marks the field readonly,
+ * hence the cast.
+ */
+export function setAgentContext(
+  agent: Agent,
+  note: Note | null,
+  hasTools: boolean,
+  referencesBlock = ''
+): void {
+  (agent.state as { systemPrompt: string }).systemPrompt = buildSystemPrompt(note, hasTools, referencesBlock);
+}
+
+/** Concatenate the text blocks of an assistant message for display. */
+export function extractText(message: AgentMessage | undefined): string {
+  if (!message || message.role !== 'assistant') return '';
+  return message.content
+    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+    .map(c => c.text)
+    .join('');
+}

--- a/src/assistant/context.ts
+++ b/src/assistant/context.ts
@@ -1,0 +1,65 @@
+/**
+ * Context assembly for the assistant.
+ *
+ * Strategy (see the integration design): inline the small and specific, search
+ * for the large and broad. The currently open note is "ambient" context and is
+ * inlined into the system prompt every turn. Anything else (other notes,
+ * notebooks, tags) is pulled on demand by the agent via the note tools.
+ */
+
+import type { Note } from '../types';
+import { exportNoteToMarkdown } from '../services/export';
+
+/** Rough token estimate (~4 chars/token). Good enough for budgeting a meter. */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+const BASE_INTRO = `You are the assistant built into Notch, a lightweight Quiver-style notebook app. You help the user think about and work with their notes.
+
+Guidelines:
+- Be concise and direct. Format replies in Markdown.
+- The user's currently open note (if any) is provided below as ambient context. Treat it as "this note" when the user refers to it.`;
+
+const TOOLS_GUIDANCE = `- To use information from OTHER notes, call the tools: search_notes to find notes by keyword, read_note to read a note's full content, and list_notebooks to see the available notebooks. Scope searches to a notebook when the user names one.
+- Do not assume notes exist that you have not seen. Search before answering questions about the wider library.
+- When you reference a note, cite it by its title.`;
+
+const NO_TOOLS_GUIDANCE = `- You can only see the currently open note shown below; you cannot search the user's other notes. If asked about a note that isn't shown, say so.`;
+
+const OUTPUT_GUIDANCE = `- You answer in chat. You do not edit the user's notes directly; if the user wants content added to a note, provide it in your reply and they will insert it.`;
+
+function baseSystemPrompt(hasTools: boolean): string {
+  return [BASE_INTRO, hasTools ? TOOLS_GUIDANCE : NO_TOOLS_GUIDANCE, OUTPUT_GUIDANCE].join('\n');
+}
+
+/** Maximum tokens to spend inlining the ambient note before truncating it. */
+const AMBIENT_NOTE_TOKEN_BUDGET = 6000;
+
+export function buildSystemPrompt(
+  currentNote: Note | null,
+  hasTools: boolean,
+  referencesBlock = ''
+): string {
+  const base = baseSystemPrompt(hasTools);
+  const refs = referencesBlock.trim()
+    ? `\n\nThe user explicitly attached these references with @-mentions:\n\n${referencesBlock}`
+    : '';
+
+  if (!currentNote) {
+    return `${base}\n\nThe user has no note open right now.${refs}`;
+  }
+
+  let noteMarkdown = exportNoteToMarkdown(currentNote);
+  let truncated = false;
+  if (estimateTokens(noteMarkdown) > AMBIENT_NOTE_TOKEN_BUDGET) {
+    noteMarkdown = noteMarkdown.slice(0, AMBIENT_NOTE_TOKEN_BUDGET * 4);
+    truncated = true;
+  }
+
+  return `${base}
+
+--- CURRENTLY OPEN NOTE (id: ${currentNote.id}) ---
+${noteMarkdown}${truncated ? '\n\n[note truncated — use read_note for the full content]' : ''}
+--- END OPEN NOTE ---${refs}`;
+}

--- a/src/assistant/mentions.ts
+++ b/src/assistant/mentions.ts
@@ -1,0 +1,92 @@
+/**
+ * @-mention references for the assistant. Typing "@" in the input lets the user
+ * pin notes and notebooks as explicit context. Following the integration design:
+ * inline the small and specific (a note's full content), index the large and
+ * broad (a notebook becomes a manifest of titles + the search/read tools).
+ */
+
+import { useStore } from '../store';
+import { getNote } from '../services/database';
+import { exportNoteToMarkdown } from '../services/export';
+import { estimateTokens } from './context';
+
+export type MentionType = 'note' | 'notebook';
+
+export interface MentionItem {
+  type: MentionType;
+  id: string;
+  label: string;
+  sublabel?: string;
+}
+
+export interface MentionRef {
+  type: MentionType;
+  id: string;
+  label: string;
+}
+
+const MAX_RESULTS = 8;
+/** Token cap per inlined referenced note. */
+const REF_NOTE_BUDGET = 4000;
+/** Max note titles listed in a notebook manifest. */
+const REF_MANIFEST_MAX = 60;
+
+function notebookName(notebookId: string): string {
+  return useStore.getState().notebooks.find(n => n.id === notebookId)?.name ?? 'Unknown';
+}
+
+/** Search notebooks and notes for the autocomplete dropdown. */
+export function searchMentions(query: string): MentionItem[] {
+  const q = query.trim().toLowerCase();
+  const { notes, notebooks } = useStore.getState();
+  const items: MentionItem[] = [];
+
+  for (const nb of notebooks) {
+    if (!q || nb.name.toLowerCase().includes(q)) {
+      items.push({ type: 'notebook', id: nb.id, label: nb.name });
+    }
+  }
+  for (const n of notes) {
+    if (n.isTrashed) continue;
+    const title = n.title || 'Untitled';
+    if (!q || title.toLowerCase().includes(q)) {
+      items.push({ type: 'note', id: n.id, label: title, sublabel: notebookName(n.notebookId) });
+    }
+  }
+  return items.slice(0, MAX_RESULTS);
+}
+
+/**
+ * Resolve pinned references into a context block for the system prompt.
+ * Notes are inlined (full content, capped); notebooks become a title manifest.
+ */
+export async function resolveReferences(refs: MentionRef[]): Promise<string> {
+  if (refs.length === 0) return '';
+  const state = useStore.getState();
+  const blocks: string[] = [];
+
+  for (const ref of refs) {
+    if (ref.type === 'note') {
+      // Prefer the in-memory note when its body is loaded; otherwise fetch it.
+      let note = state.notes.find(n => n.id === ref.id) ?? null;
+      if (!note?.bodyLoaded) note = (await getNote(ref.id)) ?? note;
+      if (!note) continue;
+      let md = exportNoteToMarkdown(note);
+      if (estimateTokens(md) > REF_NOTE_BUDGET) {
+        md = md.slice(0, REF_NOTE_BUDGET * 4) + '\n\n[truncated — use read_note for the full content]';
+      }
+      blocks.push(`--- REFERENCED NOTE: ${note.title || 'Untitled'} (id: ${note.id}) ---\n${md}`);
+    } else {
+      const titles = state.notes
+        .filter(n => n.notebookId === ref.id && !n.isTrashed)
+        .map(n => `- ${n.title || 'Untitled'} (id: ${n.id})`);
+      const capped = titles.slice(0, REF_MANIFEST_MAX);
+      const extra = titles.length > capped.length ? `\n…and ${titles.length - capped.length} more` : '';
+      blocks.push(
+        `--- REFERENCED NOTEBOOK: ${ref.label} (${titles.length} note(s)) ---\n${capped.join('\n')}${extra}\n(Use read_note with an id, or search_notes scoped to this notebook, for details.)`
+      );
+    }
+  }
+
+  return blocks.join('\n\n');
+}

--- a/src/assistant/settings.ts
+++ b/src/assistant/settings.ts
@@ -100,6 +100,19 @@ export function saveAssistantSettings(settings: AssistantSettings): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 }
 
+/**
+ * Fetch the models the endpoint advertises via the OpenAI-compatible
+ * `/models` route (Ollama serves this at /v1/models). Returns sorted unique ids.
+ */
+export async function fetchAvailableModels(baseUrl: string, apiKey: string): Promise<string[]> {
+  const url = `${baseUrl.replace(/\/+$/, '')}/models`;
+  const res = await fetch(url, apiKey ? { headers: { Authorization: `Bearer ${apiKey}` } } : undefined);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const json = (await res.json()) as { data?: { id?: string }[] };
+  const ids = (json.data ?? []).map(m => m.id).filter((id): id is string => !!id);
+  return Array.from(new Set(ids)).sort();
+}
+
 /** True when the assistant has the minimum config needed to run. */
 export function isAssistantConfigured(settings: AssistantSettings): boolean {
   return (

--- a/src/assistant/settings.ts
+++ b/src/assistant/settings.ts
@@ -1,0 +1,111 @@
+/**
+ * Assistant settings — opt-in, local-first configuration for the optional LLM
+ * assistant. Stored in localStorage (matching the app's existing config
+ * conventions in services/libraries.ts and App.tsx) so it is non-secret and
+ * never travels with a note library.
+ *
+ * The defaults mirror a local Ollama install exposing an OpenAI-compatible API,
+ * so the assistant works out of the box against a local model with no cloud key.
+ */
+
+const STORAGE_KEY = 'notch.assistant.settings';
+
+export interface AssistantSettings {
+  /** Master opt-in. When false the assistant is completely inert. */
+  enabled: boolean;
+  /** pi provider id (free-form; "ollama" for a local install). */
+  provider: string;
+  /** OpenAI-compatible base URL. */
+  baseUrl: string;
+  /** API key. For Ollama any non-empty value works ("ollama"). */
+  apiKey: string;
+  /** Model id as the provider knows it. */
+  model: string;
+  /** Context window in tokens, used for budgeting. */
+  contextWindow: number;
+  /** Max output tokens per response. */
+  maxTokens: number;
+  /**
+   * Whether to attach the note tools (search/read). Requires a tool-capable
+   * model — attaching tools to a model that lacks support makes the provider
+   * reject every request. Gemma 3 is chat-only; Gemma 4 supports tools.
+   */
+  supportsTools: boolean;
+}
+
+/** Convenience presets for a local Ollama install (mirrors ~/.pi/agent/models.json). */
+export interface ModelPreset {
+  label: string;
+  provider: string;
+  baseUrl: string;
+  model: string;
+  contextWindow: number;
+  maxTokens: number;
+  supportsTools: boolean;
+}
+
+export const LOCAL_MODEL_PRESETS: ModelPreset[] = [
+  {
+    label: 'Gemma 4 26B (Local · Ollama)',
+    provider: 'ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'gemma4:26b-a4b-it-q4_K_M',
+    contextWindow: 32768,
+    maxTokens: 8192,
+    supportsTools: true,
+  },
+  {
+    label: 'Gemma 4 E4B (Local · Ollama)',
+    provider: 'ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'gemma4:e4b',
+    contextWindow: 65536,
+    maxTokens: 8192,
+    supportsTools: true,
+  },
+  {
+    label: 'Gemma 3 4B (Local · Ollama, chat-only)',
+    provider: 'ollama',
+    baseUrl: 'http://localhost:11434/v1',
+    model: 'gemma3:4b',
+    contextWindow: 65536,
+    maxTokens: 8192,
+    supportsTools: false,
+  },
+];
+
+export const DEFAULT_SETTINGS: AssistantSettings = {
+  enabled: false,
+  provider: LOCAL_MODEL_PRESETS[0].provider,
+  baseUrl: LOCAL_MODEL_PRESETS[0].baseUrl,
+  apiKey: 'ollama',
+  model: LOCAL_MODEL_PRESETS[0].model,
+  contextWindow: LOCAL_MODEL_PRESETS[0].contextWindow,
+  maxTokens: LOCAL_MODEL_PRESETS[0].maxTokens,
+  supportsTools: LOCAL_MODEL_PRESETS[0].supportsTools,
+};
+
+export function getAssistantSettings(): AssistantSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<AssistantSettings>;
+    return { ...DEFAULT_SETTINGS, ...parsed };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveAssistantSettings(settings: AssistantSettings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+}
+
+/** True when the assistant has the minimum config needed to run. */
+export function isAssistantConfigured(settings: AssistantSettings): boolean {
+  return (
+    settings.enabled &&
+    settings.baseUrl.trim().length > 0 &&
+    settings.model.trim().length > 0 &&
+    settings.apiKey.trim().length > 0
+  );
+}

--- a/src/assistant/tools.ts
+++ b/src/assistant/tools.ts
@@ -1,0 +1,99 @@
+/**
+ * Note-aware tools handed to the pi agent. These replace the coding-agent's
+ * filesystem/bash tools entirely: the agent's only capabilities are reading and
+ * searching the user's notes. All tools are read-only — writing to notes is a
+ * separate, explicit, user-confirmed action in the UI, keeping the assistant
+ * additive (see the integration design).
+ */
+
+import { Type, type Static } from 'typebox';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { searchNotes } from '../services/search';
+import { getNote } from '../services/database';
+import { exportNoteToMarkdown } from '../services/export';
+import { useStore } from '../store';
+
+function text(s: string): { content: { type: 'text'; text: string }[]; details: undefined } {
+  return { content: [{ type: 'text', text: s }], details: undefined };
+}
+
+function notebookName(notebookId: string): string {
+  const nb = useStore.getState().notebooks.find(n => n.id === notebookId);
+  return nb?.name ?? 'Unknown notebook';
+}
+
+const SearchParams = Type.Object({
+  query: Type.String({ description: 'Keywords to search for across note titles and content.' }),
+  notebook: Type.Optional(
+    Type.String({ description: 'Optional notebook name to scope the search to.' })
+  ),
+  limit: Type.Optional(Type.Number({ description: 'Max results (default 10).' })),
+});
+
+const searchNotesTool: AgentTool<typeof SearchParams> = {
+  name: 'search_notes',
+  label: 'Search notes',
+  description:
+    'Full-text search across the user\'s notes. Returns matching note titles and ids, ranked by relevance. Use read_note to read a result.',
+  parameters: SearchParams,
+  execute: async (_id, { query, notebook, limit }: Static<typeof SearchParams>) => {
+    let notebookId: string | undefined;
+    if (notebook) {
+      const match = useStore
+        .getState()
+        .notebooks.find(n => n.name.toLowerCase() === notebook.toLowerCase());
+      if (!match) {
+        return text(`No notebook named "${notebook}". Use list_notebooks to see available notebooks.`);
+      }
+      notebookId = match.id;
+    }
+
+    const results = await searchNotes(query, { notebookId, limit: limit ?? 10 });
+    if (results.length === 0) {
+      return text(`No notes matched "${query}"${notebook ? ` in ${notebook}` : ''}.`);
+    }
+
+    const lines = results.map(
+      n => `- "${n.title}" (id: ${n.id}, notebook: ${notebookName(n.notebookId)})`
+    );
+    return text(`Found ${results.length} note(s):\n${lines.join('\n')}`);
+  },
+};
+
+const ReadParams = Type.Object({
+  id: Type.String({ description: 'The note id, as returned by search_notes.' }),
+});
+
+const readNoteTool: AgentTool<typeof ReadParams> = {
+  name: 'read_note',
+  label: 'Read note',
+  description: 'Read the full Markdown content of a note by its id.',
+  parameters: ReadParams,
+  execute: async (_id, { id }: Static<typeof ReadParams>) => {
+    const note = await getNote(id);
+    if (!note) return text(`No note found with id ${id}.`);
+    return text(
+      `Note "${note.title}" (notebook: ${notebookName(note.notebookId)}):\n\n${exportNoteToMarkdown(note)}`
+    );
+  },
+};
+
+const ListNotebooksParams = Type.Object({});
+
+const listNotebooksTool: AgentTool<typeof ListNotebooksParams> = {
+  name: 'list_notebooks',
+  label: 'List notebooks',
+  description: 'List the user\'s notebooks by name, so searches can be scoped to one.',
+  parameters: ListNotebooksParams,
+  execute: async () => {
+    const notebooks = useStore.getState().notebooks;
+    if (notebooks.length === 0) return text('There are no notebooks.');
+    return text(`Notebooks:\n${notebooks.map(n => `- ${n.name}`).join('\n')}`);
+  },
+};
+
+export const noteTools: AgentTool[] = [
+  searchNotesTool as AgentTool,
+  readNoteTool as AgentTool,
+  listNotebooksTool as AgentTool,
+];

--- a/src/components/Editor/NoteEditor.tsx
+++ b/src/components/Editor/NoteEditor.tsx
@@ -55,6 +55,8 @@ export default function NoteEditor({ showFindBar, onCloseFindBar }: NoteEditorPr
   const addTagToNote = useStore(state => state.addTagToNote);
   const removeTagFromNote = useStore(state => state.removeTagFromNote);
   const createTag = useStore(state => state.createTag);
+  const toggleAssistant = useStore(state => state.toggleAssistant);
+  const assistantVisible = useStore(state => state.assistantVisible);
 
   const [showCellTypeMenu, setShowCellTypeMenu] = useState(false);
   const [showTagMenu, setShowTagMenu] = useState(false);
@@ -82,6 +84,13 @@ export default function NoteEditor({ showFindBar, onCloseFindBar }: NoteEditorPr
   // "Text Cell" while focusedCellId catches up after a note/cell switch.
   const focusedCell = note?.cells.find(c => c.id === focusedCellId) ?? note?.cells[0] ?? null;
   const effectiveFocusedCellId = focusedCell?.id ?? null;
+
+  // Mirror the focused cell to the store so other panels (e.g. the assistant)
+  // can insert into the cell the user is actually working in.
+  const setFocusedCellIdStore = useStore(state => state.setFocusedCellId);
+  useEffect(() => {
+    setFocusedCellIdStore(effectiveFocusedCellId);
+  }, [effectiveFocusedCellId, setFocusedCellIdStore]);
   const currentCellType = focusedCell?.type || 'text';
   const currentCodeLanguage = toMonacoLanguage(focusedCell?.language || 'javascript');
   const hasKnownCodeLanguage = LANGUAGE_OPTIONS.some(option => option.id === currentCodeLanguage);
@@ -563,6 +572,15 @@ export default function NoteEditor({ showFindBar, onCloseFindBar }: NoteEditorPr
             <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
             <circle cx="8.5" cy="8.5" r="1.5"/>
             <polyline points="21 15 16 10 5 21"/>
+          </svg>
+        </button>
+        <button
+          className={`editor-footer-btn ${assistantVisible ? 'active' : ''}`}
+          title="Toggle Assistant (⌘J)"
+          onClick={() => toggleAssistant()}
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
           </svg>
         </button>
       </div>

--- a/src/components/Settings/SettingsModal.css
+++ b/src/components/Settings/SettingsModal.css
@@ -1,0 +1,51 @@
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.settings-modal {
+  width: 460px;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+}
+
+.settings-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--divider-color);
+  flex-shrink: 0;
+}
+
+.settings-modal-title {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.settings-modal-body {
+  overflow-y: auto;
+  padding: 4px 4px 12px;
+}
+
+.settings-section-title {
+  font-size: var(--font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  padding: 12px 14px 0;
+}

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -1,0 +1,37 @@
+import { useStore } from '../../store';
+import AssistantSettingsForm from '../../assistant/AssistantSettingsForm';
+import './SettingsModal.css';
+
+/**
+ * App-level Settings modal. Currently hosts the Assistant section; structured so
+ * more sections can be added. Opened via ⌘, the sidebar gear, or the assistant
+ * panel gear (all flip the `settingsOpen` store flag).
+ */
+export default function SettingsModal() {
+  const open = useStore(state => state.settingsOpen);
+  const setOpen = useStore(state => state.setSettingsOpen);
+
+  if (!open) return null;
+
+  return (
+    <div className="settings-overlay" onClick={() => setOpen(false)}>
+      <div
+        className="settings-modal"
+        role="dialog"
+        aria-label="Settings"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="settings-modal-header">
+          <span className="settings-modal-title">Settings</span>
+          <button className="assistant-icon-btn" title="Close" onClick={() => setOpen(false)}>✕</button>
+        </div>
+        <div className="settings-modal-body">
+          <section className="settings-section">
+            <div className="settings-section-title">Assistant</div>
+            <AssistantSettingsForm onSaved={() => setOpen(false)} />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -233,6 +233,7 @@ interface SidebarProps {
   onCreateLibrary?: () => void;
   onRenameLibrary?: () => void;
   onOpenLibrary?: () => void;
+  onOpenSettings?: () => void;
 }
 
 export default function Sidebar({
@@ -242,6 +243,7 @@ export default function Sidebar({
   onCreateLibrary,
   onRenameLibrary,
   onOpenLibrary,
+  onOpenSettings,
 }: SidebarProps = {}) {
   const [activeTab, setActiveTab] = useState<'notebooks' | 'tags'>('notebooks');
   const [newItemName, setNewItemName] = useState('');
@@ -452,6 +454,16 @@ export default function Sidebar({
             <span className="library-switcher-name">{activeLibrary.name}</span>
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <polyline points="6 9 12 15 18 9"/>
+            </svg>
+          </button>
+          <button
+            className="sidebar-settings-btn"
+            title="Settings (⌘,)"
+            onClick={() => onOpenSettings?.()}
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="3"/>
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
             </svg>
           </button>
           {showLibraryMenu && (

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ Bun.serve({
     // not code-split, so they land in the eager bundle. Bun's HMR transform
     // currently emits invalid JS for one of those modules ("Invalid
     // destructuring assignment target"), which blanks the whole app. Bun still
-    // live-reloads on save without HMR. Production builds (--splitting) are
-    // unaffected. Re-enable once the upstream Bun HMR bug is fixed.
+    // live-reloads on save without HMR. Production builds are unaffected.
+    // Re-enable once the upstream Bun HMR bug is fixed.
     hmr: false,
     console: true,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,14 @@ Bun.serve({
     '/': index,
   },
   development: {
-    hmr: true,
+    // HMR is disabled: the optional assistant bundles LLM provider SDKs
+    // (@earendil-works/pi-ai → openai/anthropic/etc.), and the dev server does
+    // not code-split, so they land in the eager bundle. Bun's HMR transform
+    // currently emits invalid JS for one of those modules ("Invalid
+    // destructuring assignment target"), which blanks the whole app. Bun still
+    // live-reloads on save without HMR. Production builds (--splitting) are
+    // unaffected. Re-enable once the upstream Bun HMR bug is fixed.
+    hmr: false,
     console: true,
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,12 +25,14 @@ export const useStore = create<Store>((set, get) => ({
   layoutMode: 'triple',
   editorViewMode: 'split',
   sidebarVisible: true,
+  assistantVisible: false,
 
   // Initial selection state
   selectedNotebookId: null,
   selectedNoteId: null,
   selectedCollection: 'all',
   selectedTagId: null,
+  focusedCellId: null,
 
   // Initial data
   notebooks: [],
@@ -52,6 +54,12 @@ export const useStore = create<Store>((set, get) => ({
   setEditorViewMode: (mode: EditorViewMode) => set({ editorViewMode: mode }),
 
   toggleSidebar: () => set(state => ({ sidebarVisible: !state.sidebarVisible })),
+
+  toggleAssistant: () => set(state => ({ assistantVisible: !state.assistantVisible })),
+
+  setAssistantVisible: (visible: boolean) => set({ assistantVisible: visible }),
+
+  setFocusedCellId: (id: string | null) => set({ focusedCellId: id }),
 
   // ==================== SELECTION ACTIONS ====================
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,6 +26,8 @@ export const useStore = create<Store>((set, get) => ({
   editorViewMode: 'split',
   sidebarVisible: true,
   assistantVisible: false,
+  settingsOpen: false,
+  assistantSettingsVersion: 0,
 
   // Initial selection state
   selectedNotebookId: null,
@@ -58,6 +60,10 @@ export const useStore = create<Store>((set, get) => ({
   toggleAssistant: () => set(state => ({ assistantVisible: !state.assistantVisible })),
 
   setAssistantVisible: (visible: boolean) => set({ assistantVisible: visible }),
+
+  setSettingsOpen: (open: boolean) => set({ settingsOpen: open }),
+
+  bumpAssistantSettings: () => set(state => ({ assistantSettingsVersion: state.assistantSettingsVersion + 1 })),
 
   setFocusedCellId: (id: string | null) => set({ focusedCellId: id }),
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -216,8 +216,31 @@ body {
 
 .library-switcher {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   padding: 8px;
   border-bottom: 1px solid var(--border-color);
+}
+.library-switcher-button {
+  flex: 1;
+  min-width: 0;
+}
+.sidebar-settings-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+.sidebar-settings-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 .library-switcher-button {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,10 @@ export interface AppState {
   editorViewMode: EditorViewMode;
   sidebarVisible: boolean;
   assistantVisible: boolean;
+  /** Whether the app Settings modal is open. */
+  settingsOpen: boolean;
+  /** Bumped whenever assistant settings are saved, so consumers can re-read them. */
+  assistantSettingsVersion: number;
 
   // Selection state
   selectedNotebookId: string | null;
@@ -108,6 +112,8 @@ export interface AppActions {
   toggleSidebar: () => void;
   toggleAssistant: () => void;
   setAssistantVisible: (visible: boolean) => void;
+  setSettingsOpen: (open: boolean) => void;
+  bumpAssistantSettings: () => void;
 
   // Selection actions
   selectNotebook: (id: string | null) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,12 +76,15 @@ export interface AppState {
   layoutMode: LayoutMode;
   editorViewMode: EditorViewMode;
   sidebarVisible: boolean;
+  assistantVisible: boolean;
 
   // Selection state
   selectedNotebookId: string | null;
   selectedNoteId: string | null;
   selectedCollection: SpecialCollection | null;
   selectedTagId: string | null;
+  /** Id of the cell currently focused in the editor (mirrored from NoteEditor for cross-component use). */
+  focusedCellId: string | null;
 
   // Data
   notebooks: Notebook[];
@@ -103,12 +106,15 @@ export interface AppActions {
   setLayoutMode: (mode: LayoutMode) => void;
   setEditorViewMode: (mode: EditorViewMode) => void;
   toggleSidebar: () => void;
+  toggleAssistant: () => void;
+  setAssistantVisible: (visible: boolean) => void;
 
   // Selection actions
   selectNotebook: (id: string | null) => void;
   selectNote: (id: string | null) => void;
   selectCollection: (collection: SpecialCollection | null) => void;
   selectTag: (id: string | null) => void;
+  setFocusedCellId: (id: string | null) => void;
 
   // Notebook actions
   createNotebook: (name: string, parentId?: string) => Promise<Notebook>;


### PR DESCRIPTION
## Summary

Adds an optional, opt-in LLM assistant side panel built on the [pi](https://github.com/earendil-works) harness. The default UX is unchanged — the assistant is disabled until enabled in Settings, and none of its code runs until the panel is opened.

- **Assistant panel** (`⌘J`): chat with an LLM about your notes, with `@mention` references to notes and optional note search/read tools for tool-capable models.
- **Settings modal** (`⌘,`): configure provider, base URL, API key, and model, with models auto-detected from the endpoint's OpenAI-compatible `/models` route. Defaults target a local Ollama install, so it works fully locally (tested with Gemma + Ollama) with no cloud key.
- **Build fix**: `--splitting` was originally added so the assistant and its provider SDKs would code-split out of the startup bundle, but the resulting cross-chunk ES module imports fail to resolve under the packaged app's webview protocol (`tauri://localhost`), leaving a blank window on launch. Dropped it — everything bundles into one file, verified working in the packaged .app.
- Dev-server HMR is disabled for now: Bun's HMR transform emits invalid JS for one of the provider SDK modules, which also blanked the app. Plain live-reload still works.

## Test plan

- [x] Packaged build (`bun run build`) launches and renders the library (was blank with `--splitting`)
- [x] Assistant disabled by default; core editor UX unchanged
- [x] Settings modal detects local Ollama models; assistant chats against a local Gemma model
- [x] `bun test` passes

https://claude.ai/code/session_01EdeHdGz6yzYgXHU1fvZHMd