### PR TITLE
chore(build): add build:local script that skips updater artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "bunx tauri dev",
     "dev:frontend": "bun run --hot src/index.ts",
     "build": "bunx tauri build",
+    "build:local": "bunx tauri build --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
     "build:frontend": "bun build src/index.html --outdir dist --production",
     "preview": "bun run src/index.ts",
     "test": "bun test",


### PR DESCRIPTION
## Summary

`bun run build` currently fails at the very end for anyone without the release signing key:

```
A public key has been found, but no private key. Make sure to set `TAURI_SIGNING_PRIVATE_KEY` environment variable.
error: script "build" exited with code 1
```

The `.app`/`.dmg` bundles are actually produced before the error — only the updater-artifact signing fails — but the non-zero exit is confusing for contributors building locally.

This adds a `build:local` script that overrides `createUpdaterArtifacts` via Tauri's `--config` merge, so local builds exit cleanly without touching the committed updater config or the release pipeline:

```json
"build:local": "bunx tauri build --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'"
```

## Test plan

- [x] `bun run build:local` compiles, bundles .app and .dmg, and exits 0 with no signing error
- [x] `bun run build` unchanged

https://claude.ai/code/session_01EdeHdGz6yzYgXHU1fvZHMd